### PR TITLE
Add key attribute to ViewComponent render call

### DIFF
--- a/src/process/Process.js
+++ b/src/process/Process.js
@@ -159,6 +159,7 @@ function renderCurrentView()
                             {
                                 ViewComponent && (
                                     <ViewComponent
+                                        key={ `processId-${process.id}` }
                                         env={ env }
                                     />
                                 )


### PR DESCRIPTION
To rerender the ViewComponent on process id change, a key attribute with
the process id is now attached to the element.