### PR TITLE
Navitree Folder: show context menu with only 1 action

### DIFF
--- a/src/ui/tree/Folder.js
+++ b/src/ui/tree/Folder.js
@@ -141,7 +141,7 @@ const Folder = ({row, render, query, variables, onLoad, actions, children}) => {
                     </button>
                 </div>
                 {
-                    actions && actions.length > 1 && (
+                    actions && actions.length >= 1 && (
                         <ItemMenuWrapper
                             ctx={ctx}
                             selectionId={selectionId}


### PR DESCRIPTION
Navigation tree folders now show their context menu when only 1 action
is attached to them.

In the navigation tree, tree objects only show their context menu if
at least 2 actions are attached to them. Since the first action is
also executed on left click, the context menu is not necessary if only
one action is attached.

On tree folders however, left click doesn't execute the first action,
so here the context menu also has to show when only 1 action is present.