### PR TITLE
Use function in promiseUI defaultReject.render

### DIFF
--- a/src/util/promiseUI.js
+++ b/src/util/promiseUI.js
@@ -207,6 +207,11 @@ export default function promiseUI(promise, options)
             })
         },
         err => {
+            if (typeof defaultReject.render === "function")
+            {
+                defaultReject.render = defaultReject.render(err);
+            }
+
             toast.update(
                 toastId,
                 {

--- a/src/util/promiseUI.js
+++ b/src/util/promiseUI.js
@@ -207,16 +207,17 @@ export default function promiseUI(promise, options)
             })
         },
         err => {
+            const clonedDefaultRejectOptions = {...defaultReject};
             if (typeof defaultReject.render === "function")
             {
-                defaultReject.render = defaultReject.render(err);
+                clonedDefaultRejectOptions.render = defaultReject.render(err);
             }
 
             toast.update(
                 toastId,
                 {
                     ... resetLoadingParams,
-                    ... defaultReject
+                    ... clonedDefaultRejectOptions
                 }
             )
             return Promise.reject(err);


### PR DESCRIPTION
You can now use a function in the defaultReject.render of the promiseUI. The result of the defined function is set as defaultReject.render. As a result of this you are able to easily display the reason of Promise.reject() instead of a generic error message.