### PR TITLE
Register i18n to domainql-form

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,5 +1,5 @@
+import { registerI18n } from "domainql-form";
 import config from "./config";
-
 
 function format(tag, args)
 {
@@ -53,3 +53,5 @@ export default function i18n(key, ...args) {
     }
     return wrap(key);
 };
+
+registerI18n(i18n);


### PR DESCRIPTION
As domainql-form is not responsible for loading the translations, but
also adding content that needs to be translated (error messages), we
need to pass the translation function i18n to it.
This enables the error messages to be translated with minimal effort.