### PR TITLE
Activate change marker for special cases

### DIFF
--- a/src/ui/AssociationSelector.js
+++ b/src/ui/AssociationSelector.js
@@ -411,6 +411,7 @@ const AssociationSelector = fnObserver(props => {
                         className="btn btn-light"
                         onClick={ openModal }
                         disabled={isDisabled}
+                        name={ name }
                     >
                         <Icon className="fa-clipboard-check mr-1"/>
                         Select

--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -42,7 +42,7 @@ const COLUMN_CONFIG_INPUT_OPTS = {
  */
 const DataGrid = fnObserver(props => {
 
-    const { id, value, isCompact, tableClassName, rowClasses, filterTimeout, workingSet, children } = props;
+    const { id, name, value, isCompact, tableClassName, rowClasses, filterTimeout, workingSet, children } = props;
 
     const { type, columnStates } = value;
 
@@ -179,6 +179,7 @@ const DataGrid = fnObserver(props => {
                                 tableClassName
                             )
                         }
+                        name={name}
                     >
                         <thead>
                         <tr className="headers">


### PR DESCRIPTION
The change marker was not shown for AssociationSelector and DataGrid in
forms.
The old reference to section was stored inside the fieldContext which is
not used in special cases. To counter that the reference is now stored
in the dataset of the associated dom element.
For AssociationSelector this is the button element used to select
entries, for DataGrid the table itself is used.
To achieve this a new propery "name" was added to DataGrid which is
expected to reference the domainObject name.
This change to DataGrid ensures that adding or removing entries will
not break the change marker behaviour for shortcuts.

For AssociationSelector usage no changes have to be made.
DataGrids however need to add the new "name" property to fully enable
the feature:
`<DataGrid ... name="{domainObject name}">...</DataGrid>`