### PR TITLE
Fix FKSelector update on data change

### DIFF
--- a/src/ui/FKSelector.js
+++ b/src/ui/FKSelector.js
@@ -376,6 +376,7 @@ const FKSelector = fnObserver(props => {
                         [ gqlMethodName ]
                     );
 
+                    const fieldValue = Field.getValue(formConfig, ctx, errorMessages);
                     useEffect(
                         () => {
                             if (!haveErrors && !userIsTyping)
@@ -390,6 +391,7 @@ const FKSelector = fnObserver(props => {
                                 }
                             }
                         },
+                        [fieldValue]
                     );
 
                     const debouncedInputValidation = useDebouncedCallback(


### PR DESCRIPTION
The FKSelector did not update properly on background data changes.
This was due to a lack of checking for changed field values for the
useEffect and accordingly not triggering the setInputValue.