### PR TITLE
Add support for custom filter alias

### DIFF
--- a/src/FilterDSL.js
+++ b/src/FilterDSL.js
@@ -400,7 +400,7 @@ export function getConditionArgCount(name)
 {
     if (typeof name === "function")
     {
-        return name.length;
+        return name.length - 1;
     }
 
     const count = CONDITION_METHODS[name] || FIELD_CONDITIONS[name];

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,8 @@ import ConditionEditor from "./ui/condition/ConditionEditor"
 import {unwrapNonNull} from "./util/type-utils";
 import decompileFilter from "./util/decompileFilter"
 
+import { registerCustomFilter } from "./util/CustomFilter"
+
 // noinspection JSUnusedGlobalSymbols
 export {
     config,
@@ -186,6 +188,8 @@ export {
     ConditionEditor,
     confirmDestructiveTransition,
     unwrapNonNull,
-    decompileFilter
+    decompileFilter,
+
+    registerCustomFilter
 }
 

--- a/src/ui/FkSelectorModal.js
+++ b/src/ui/FkSelectorModal.js
@@ -232,7 +232,7 @@ const FkSelectorModal = fnObserver(
                                                         showColumnFilter ? (
                                                             columnTypes[idx] === "String" ?
                                                                 "containsIgnoreCase" :
-                                                                val =>
+                                                                (fieldName, val) =>
                                                                     field(name).toString()
                                                                     .containsIgnoreCase(
                                                                         value(val, "String")

--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -16,6 +16,7 @@ import WorkingSetStatusComponent from "./WorkingSetStatus";
 import filterTransformer, { FieldResolver } from "../../util/filterTransformer";
 import config from "../../config"
 import { toJS } from "mobx";
+import { getCustomFilter } from "../../util/CustomFilter";
 
 
 function findColumn(columnStates, name)
@@ -79,6 +80,7 @@ const DataGrid = fnObserver(props => {
                 }
 
                 const {name, width, minWidth, filter, heading, sort, renderFilter } = columnElem.props;
+                const transformedFilter = getCustomFilter(filter) ?? filter;
 
                 let typeRef = null, sortable = false, enabled = false;
                 if (name)
@@ -90,7 +92,7 @@ const DataGrid = fnObserver(props => {
                         sortable = columnState.sortable;
                         const typeContext = lookupTypeContext(type, name);
 
-                        if (filter && typeof filter !== "function" && config.inputSchema.getFieldMeta(typeContext.domainType, typeContext.field.name, "computed"))
+                        if (transformedFilter && typeof transformedFilter !== "function" && config.inputSchema.getFieldMeta(typeContext.domainType, typeContext.field.name, "computed"))
                         {
                             throw new Error(
                                 "Computed column '" + typeContext.field.name + "' cannot be filtered with a simple filter.\n" +
@@ -123,7 +125,7 @@ const DataGrid = fnObserver(props => {
                     width,
                     minWidth,
                     sortable,
-                    filter,
+                    filter: transformedFilter,
                     enabled,
                     type: typeRef && typeRef.name,
                     heading: heading || name,

--- a/src/ui/datagrid/GridStateForm.js
+++ b/src/ui/datagrid/GridStateForm.js
@@ -83,7 +83,7 @@ function createValues(filter, column, columnCondition)
 
         list[i] = {
             type: valueNode ? valueNode.scalarType : column.type,
-            label: i === 0 ? i18n("Filter:" + name) : null,
+            label: i === 0 ? i18n("Filter:" + column.name) : null,
             value: valueNode ? valueNode.value : null
         };
     }
@@ -216,7 +216,7 @@ function findColumnCondition(componentId = null, name, currentCondition)
 }
 
 
-export function invokeForTemplate(filter)
+export function invokeForTemplate(fieldName, filter)
 {
     const { length } = filter;
 
@@ -226,7 +226,7 @@ export function invokeForTemplate(filter)
         args[i] = null;
     }
 
-    return  filter.apply(null, args);
+    return  filter.call(null, fieldName, ...args);
 }
 
 
@@ -282,12 +282,12 @@ function resolveFilters(columns, componentId, currentCondition)
     for (let i = 0; i < columns.length; i++)
     {
         const column = columns[i];
-        const { filter } = column;
+        const { name, filter } = column;
         if (filter)
         {
             if (typeof filter === "function")
             {
-                const template = invokeForTemplate(filter);
+                const template = invokeForTemplate(name, filter);
 
                 const columnCondition = findConditionByTemplate(
                     componentId,
@@ -390,17 +390,16 @@ const GridStateForm = props => {
                     if (allValuesSet(values))
                     {
                         let cond;
+                        const fieldName = columns[columnIndex].name;
                         if (typeof filter === "function")
                         {
-                            cond = filter(... values.map(v => v.value))
+                            cond = filter(fieldName, ... values.map(v => v.value))
                         }
                         else
                         {
                             cond = condition(filter);
                             cond.operands = [
-                                field(
-                                    columns[columnIndex].name
-                                ),
+                                field(fieldName),
                                 ... values.map( v => value(toJS(v.value), v.type))
                             ];
 

--- a/src/util/CustomFilter.js
+++ b/src/util/CustomFilter.js
@@ -12,9 +12,22 @@ export function getCustomFilter(name) {
     return null;
 }
 
-export function resetConverter()
+/**
+ * Remove all stored filters
+ */
+export function removeAllCustomFilters()
 {
     filter = {};
+}
+
+/**
+ * Remove a stored filter by alias
+ *
+ * @param {String} name                     filter alias
+ */
+export function removeCustomFilter(name)
+{
+    filter[name] = null;
 }
 
 /**

--- a/src/util/CustomFilter.js
+++ b/src/util/CustomFilter.js
@@ -1,0 +1,29 @@
+let filter = {};
+
+/**
+ * Returns a stored filter by alias
+ *
+ * @param {String} name                     filter alias
+ */
+export function getCustomFilter(name) {
+    if (name in filter) {
+        return filter[name];
+    }
+    return null;
+}
+
+export function resetConverter()
+{
+    filter = {};
+}
+
+/**
+ * Register new filter alias
+ *
+ * @param {String} name                     filter alias
+ * @param {function|String} filterFn        filter function or name to be executed if filter is applied
+ */
+export function registerCustomFilter(name, filterFn)
+{
+    filter[name] = filterFn;
+}


### PR DESCRIPTION
It is now possible to register custom filter for DataGrid as alias to
be interpreted instead of registering the same filter function multiple
times for many Columns. That way errors are less prone to happen and
the overall readability and usability of code is enhanced.

To use this the functionality registerCustomFilter in CustomFilter has
to be executed with the first parameter being the alias and the second
being filter function to be executed (or a built-in filter name).
The registerCustomFilter function is also exported by the index.
All filter fnctions will now have the fieldName associated with as first
parameter.