### PR TITLE
Add suspendAutoUpdate property

### DIFF
--- a/src/model/InteractiveQuery.js
+++ b/src/model/InteractiveQuery.js
@@ -35,7 +35,6 @@ const updateFromResult = action("Update iQuery from Result", (iQuery, result) =>
     //console.log("updateFromResult: queryConfig =", JSON.stringify(value.queryConfig));
 
     iQuery.rows.replace(value.rows);
-    Object.assign(iQuery.queryConfig, value.queryConfig);
     iQuery.columnStates.replace(value.columnStates);
     iQuery.rowCount = value.rowCount;
 
@@ -153,6 +152,8 @@ export default class InteractiveQuery {
             {
                 vars.config.condition = null;
             }
+
+            Object.assign(this.queryConfig, vars.config);
         }
         else
         {

--- a/src/ui/datagrid/FilterRow.js
+++ b/src/ui/datagrid/FilterRow.js
@@ -80,7 +80,8 @@ const FilterRow = fnObserver(props => {
                                 React.cloneElement(
                                     customElem,
                                     {
-                                        key
+                                        key,
+                                        suspendAutoUpdate: true
                                     }
                                 )
                             );
@@ -94,6 +95,7 @@ const FilterRow = fnObserver(props => {
                                     label={ label }
                                     name={fieldName}
                                     type={ fieldType }
+                                    suspendAutoUpdate
                                 />
                             );
                         }


### PR DESCRIPTION
Add property suspendAutoUpdate to Field.
Setting this property will prevent the automatic update of the field
contents.

Fix order of operations in InteractiveQuery to prevent client query
config from being overridden by server return value.