### PR TITLE
Add OfflineQuery and enable DataGrid array usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { storeDomainObject, deleteDomainObject, storeDomainObjects, generateDoma
 import { backToParent } from "./process/back-functions"
 import { getGenericType, getWireFormat } from "./domain"
 import InteractiveQuery, { getFirstValue } from "./model/InteractiveQuery"
+import { OfflineQuery } from "./model/OfflineQuery";
 import createDomainObject from "./createDomainObject"
 import LogoutForm from "./ui/LogoutForm"
 import extractTypeData from "./extractTypeData"
@@ -116,6 +117,7 @@ export {
 
     getGenericType,
     InteractiveQuery,
+    OfflineQuery,
     getFirstValue,
 
 

--- a/src/model/OfflineQuery.js
+++ b/src/model/OfflineQuery.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2022, QuinScape GmbH. All rights reserved.
+ */
+
+
+import {action, makeObservable, observable} from "mobx";
+import updateComponentCondition from "../util/updateComponentCondition";
+import { isConditionObject } from "../FilterDSL";
+import filterTransformer, { FieldResolver } from "../util/filterTransformer";
+import InteractiveQuery from "./InteractiveQuery";
+
+const fieldResolver = new FieldResolver();
+
+function filterBy(data, condition) {
+    if (isConditionObject(condition)) {
+        const filterFn = filterTransformer(condition, fieldResolver.resolve);
+        return data.filter(row => {
+            fieldResolver.current = row;
+            return filterFn();
+        });
+    }
+    return data.slice();
+}
+
+function sortRowsByFields(rows, sortFields) {
+    return rows.sort((row0, row1) => {
+        for (const sortField of sortFields) {
+            const order = sortField.startsWith("!") ? -1 : 1;
+            const fieldName = order === -1 ? sortField.slice(1) : sortField;
+            if (row0[fieldName] < row1[fieldName]) {
+                return order;
+            } else if (row0[fieldName] > row1[fieldName]) {
+                return -order;
+            }
+        }
+        return 0;
+    });
+}
+
+export class OfflineQuery
+{
+
+    @observable
+    queryConfig;
+
+    @observable
+    rows
+
+    @observable
+    columnStates
+
+    /**
+     * Creates a new OfflineQuery
+     * 
+     * @param {InteractiveQuery | Object[]} source     source iQuery document containing all rows
+     */
+    constructor(source)
+    {
+        if (Array.isArray(source)) {
+            this.data = source;
+            this.rowCount = this.data.length;
+            this.queryConfig = {
+                "_type": "QueryConfig",
+                "pageSize": 10,
+                "condition": null,
+                "sortFields": [],
+                "id": null,
+                "offset": 0
+            };
+            this.columnStates = [];
+            for (const columnName in source[0]) {
+                if (columnName != "_type") {
+                    this.columnStates.push({
+                        "_type": "ColumnState",
+                        "name": columnName,
+                        "sortable": true,
+                        "enabled": true
+                    });
+                }
+            }
+            this.type = null;
+            this._type = "OfflineQuery";
+        } else if (source instanceof InteractiveQuery) {
+            this.data = source.rows;
+            this.rowCount = this.data.length;
+            this.queryConfig = source.queryConfig;
+            this.columnStates = source.columnStates;
+            this.type = source.type;
+            this._type = `OfflineQuery${source.type}`;
+        } else {
+            throw new Error('source muss ein InteractiveQuery oder ein Array sein.');
+        }
+        this.update();
+        makeObservable(this);
+    }
+
+    /**
+     * Updates the current resolved rows based on a new query config.
+     * 
+     * The given query config is merged with the current config so you only need to define the changes.
+     *
+     * Examples:
+     *
+     * ```js
+     * // page to second page
+     * iQuery.update({offset: 10})
+     *
+     * // sorty by name descending
+     * iQuery.update({
+     *     sortFields: [ "!name" ]
+     * })
+     * ```
+     *
+     * @param {Object} queryConfig      query config structure (see de.quinscape.automaton.model.data.QueryConfig)
+     * @return {Promise<* | never>}
+     */
+    @action
+    update(value)
+    {
+        if (value != null) {
+            this.queryConfig = {...this.queryConfig, ...value};
+        }
+        const {offset, pageSize, sortFields, condition} = this.queryConfig;
+
+        const filteredRows = filterBy(this.data, condition);
+        const sortedRows = sortRowsByFields(filteredRows, sortFields);
+        this.rowCount = sortedRows.length;
+        this.rows = sortedRows.slice(offset, offset + pageSize);
+    }
+
+
+
+    /**
+     * Updates a component condition in the current query config state.
+     *
+     * If no component node is found, the current condition if present will be ANDed with the component condition
+     *
+     * @param {Object} componentCondition   condition node
+     * @param {String} [componentId]        component id if none is given NO_COMPONENT (null) will be used
+     * @param {Boolean} [checkConditions]     check component condition before updating, don't update if identical
+     * @return {Promise<* | never>}
+     */
+    @action
+    updateCondition(
+        componentCondition,
+        componentId = NO_COMPONENT,
+        checkConditions = true
+    )
+    {
+        let {condition: currentCondition} = this.queryConfig;
+
+        const newCondition = updateComponentCondition(
+            currentCondition,
+            componentCondition,
+            componentId,
+            checkConditions
+        );
+
+        if (newCondition === currentCondition)
+        {
+            return Promise.resolve(true);
+        }
+
+        return this.update({
+            condition: newCondition,
+            offset: 0
+        })
+    }
+
+}
+

--- a/src/model/OfflineQuery.js
+++ b/src/model/OfflineQuery.js
@@ -37,6 +37,11 @@ function sortRowsByFields(rows, sortFields) {
     });
 }
 
+/**
+ * Offline version of {@link InteractiveQuery} emulating sort, filter and paging functionality.
+ *
+ * @category iquery
+ */
 export class OfflineQuery
 {
 
@@ -50,9 +55,9 @@ export class OfflineQuery
     columnStates
 
     /**
-     * Creates a new OfflineQuery
+     * Creates a new OfflineQuery running either on array data or the result of an executed {@link InteractiveQuery}
      * 
-     * @param {InteractiveQuery | Object[]} source     source iQuery document containing all rows
+     * @param {InteractiveQuery | Object[]} source     source iQuery document or array containing all rows
      */
     constructor(source)
     {

--- a/src/ui/FKSelector.js
+++ b/src/ui/FKSelector.js
@@ -43,6 +43,7 @@ import { SCALAR } from "domainql-form/lib/kind";
 import CachedQuery from "../model/CachedQuery";
 import updateComponentCondition from "../util/updateComponentCondition"
 import {and} from "../../filter";
+import { OfflineQuery } from "../model/OfflineQuery";
 
 
 export const NO_SEARCH_FILTER = "NO_SEARCH_FILTER";
@@ -259,6 +260,10 @@ const FKSelector = fnObserver(props => {
                     queryFromProps, {
                         pageSize: cachedPageSize
                     });
+            }
+            else if (queryFromProps instanceof OfflineQuery)
+            {
+                return queryFromProps;
             }
             else
             {

--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -17,6 +17,7 @@ import filterTransformer, { FieldResolver } from "../../util/filterTransformer";
 import config from "../../config"
 import { toJS } from "mobx";
 import { getCustomFilter } from "../../util/CustomFilter";
+import { OfflineQuery } from "../../../lib";
 
 
 function findColumn(columnStates, name)
@@ -45,7 +46,14 @@ const DataGrid = fnObserver(props => {
 
     const { id, name, value, isCompact, tableClassName, rowClasses, filterTimeout, workingSet, children } = props;
 
-    const { type, columnStates } = value;
+    const [suppressFilter, internalQuery] = useMemo(() => {
+        if (Array.isArray(value)) {
+            return [true, new OfflineQuery(value)];
+        }
+        return [false, value];
+    }, [value]);
+
+    const { type, columnStates } = internalQuery;
 
     const columnStatesInput = useObservableInput(
         () => {
@@ -90,21 +98,24 @@ const DataGrid = fnObserver(props => {
                     if (columnState && columnState.enabled)
                     {
                         sortable = columnState.sortable;
-                        const typeContext = lookupTypeContext(type, name);
 
-                        if (transformedFilter && typeof transformedFilter !== "function" && config.inputSchema.getFieldMeta(typeContext.domainType, typeContext.field.name, "computed"))
-                        {
-                            throw new Error(
-                                "Computed column '" + typeContext.field.name + "' cannot be filtered with a simple filter.\n" +
-                                "You need to write a custom filter function that basically reimplements the computed in SQL and produces a matching filter expression."
-                            )
-                        }
-
-
-                        typeRef = unwrapAll(typeContext.field.type);
-                        if (typeRef.kind !== "SCALAR")
-                        {
-                            throw new Error("Column type is no scalar: " + name);
+                        if (type) {
+                            const typeContext = lookupTypeContext(type, name);
+    
+                            if (transformedFilter && typeof transformedFilter !== "function" && config.inputSchema.getFieldMeta(typeContext.domainType, typeContext.field.name, "computed"))
+                            {
+                                throw new Error(
+                                    "Computed column '" + typeContext.field.name + "' cannot be filtered with a simple filter.\n" +
+                                    "You need to write a custom filter function that basically reimplements the computed in SQL and produces a matching filter expression."
+                                )
+                            }
+    
+    
+                            typeRef = unwrapAll(typeContext.field.type);
+                            if (typeRef.kind !== "SCALAR")
+                            {
+                                throw new Error("Column type is no scalar: " + name);
+                            }
                         }
                         enabled = true;
                         enabledCount++;
@@ -127,7 +138,7 @@ const DataGrid = fnObserver(props => {
                     sortable,
                     filter: transformedFilter,
                     enabled,
-                    type: typeRef && typeRef.name,
+                    type: typeRef?.name,
                     heading: heading || name,
                     sort: sort || name,
                     renderFilter,
@@ -150,7 +161,7 @@ const DataGrid = fnObserver(props => {
         [ type, columnStatesInput ]
     );
 
-    const { rows, queryConfig } = value;
+    const { rows, queryConfig } = internalQuery;
 
     const fieldResolver = useMemo(
         () => new FieldResolver(),
@@ -159,7 +170,7 @@ const DataGrid = fnObserver(props => {
 
     return (
         <GridStateForm
-            iQuery={ value }
+            iQuery={ internalQuery }
             columns={ columns }
             componentId={ id }
             filterTimeout={ filterTimeout }
@@ -199,7 +210,7 @@ const DataGrid = fnObserver(props => {
                                             }
                                         >
                                             <SortLink
-                                                iQuery={ value }
+                                                iQuery={ internalQuery }
                                                 column={ col }
                                             />
                                         </th>
@@ -207,10 +218,13 @@ const DataGrid = fnObserver(props => {
                                 )
                             }
                         </tr>
-
-                        <FilterRow
-                            columns={ columns }
-                        />
+                        {
+                            !suppressFilter && (
+                                <FilterRow
+                                    columns={ columns }
+                                />
+                            )
+                        }
                         </thead>
                         <tbody>
                         {
@@ -318,7 +332,7 @@ const DataGrid = fnObserver(props => {
                 </div>
             </div>
             <Pagination
-                iQuery={ value }
+                iQuery={ internalQuery }
                 description={ i18n("Result Navigation") }
             />
         </GridStateForm>


### PR DESCRIPTION
Add OfflineQuery to enable paging, filtering and sorting preloaded data.
OfflineQueries can be generated with an InteractiveQuery or an Array as
base, where the latter will disable the filter functionality of DataGrid
as we can currently not determine the field definitions for the filters
without a base type.
DataGrid will automatically convert array data into OfflineQuery.

Allow usage of OfflineQuery in FKSelector.
OfflineQuery in FKSelector with array base data has to be tested.