### PR TITLE
Fix import path of domainql-form Icon

### DIFF
--- a/src/ui/form/date/components/DateTimeCalendar.js
+++ b/src/ui/form/date/components/DateTimeCalendar.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react"
 import Calendar from "react-calendar"
 import {DateTime} from "luxon";
-import {Icon} from "../../../../../../domainql-form";
+import {Icon} from "domainql-form";
 import i18n from "../../../../i18n";
 import {Container} from "reactstrap";
 


### PR DESCRIPTION
The import path in DateTimeCalendar was pointing to the relative path
but should be using the namespace instead.