### PR TITLE
Enable pagination page size definition through application

### DIFF
--- a/src/ui/AssociationSelector.js
+++ b/src/ui/AssociationSelector.js
@@ -266,6 +266,7 @@ const AssociationSelector = fnObserver(props => {
         onNew,
         visibleColumns,
         alignPagination,
+        paginationPageSizes,
         disabled
     } = props;
 
@@ -426,6 +427,7 @@ const AssociationSelector = fnObserver(props => {
                 toggle={toggle}
                 fade={fade}
                 alignPagination={ alignPagination }
+                paginationPageSizes={ paginationPageSizes }
             />
         </React.Fragment>
     )
@@ -522,6 +524,11 @@ AssociationSelector.propTypes = {
      * set the pagination alignment of the datagrid in the modal ("left" [default], "center", "right")
      */
      alignPagination: PropTypes.string,
+
+    /**
+     * set the available page sizes for the datagrid pagination
+     */
+    paginationPageSizes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
 
 };
 

--- a/src/ui/AssociationSelectorModal.js
+++ b/src/ui/AssociationSelectorModal.js
@@ -21,7 +21,8 @@ const AssociationSelectorModal = fnObserver(props => {
         fade,
         selected,
         idPath,
-        alignPagination
+        alignPagination,
+        paginationPageSizes
     } = props;
 
     return(
@@ -42,6 +43,7 @@ const AssociationSelectorModal = fnObserver(props => {
                                 tableClassName="table-hover table-striped table-bordered table-sm"
                                 value={ iQuery }
                                 alignPagination={ alignPagination }
+                                paginationPageSizes={ paginationPageSizes }
                                 isCompact
                             >
                                 <DataGrid.Column

--- a/src/ui/FKSelector.js
+++ b/src/ui/FKSelector.js
@@ -244,6 +244,7 @@ const FKSelector = fnObserver(props => {
         selectButtonContentRenderer,
         visibleColumns,
         alignPagination,
+        paginationPageSizes,
         ... fieldProps
     } = props;
 
@@ -692,6 +693,7 @@ const FKSelector = fnObserver(props => {
                                 fkSelectorId={ fkSelectorId }
                                 selectButtonContentRenderer={ selectButtonContentRenderer }
                                 alignPagination={ alignPagination }
+                                paginationPageSizes={ paginationPageSizes }
                             />
                         </FormGroup>
                     );
@@ -854,6 +856,11 @@ FKSelector.propTypes = {
      * set the pagination alignment of the datagrid in the modal ("left" [default], "center", "right")
      */
     alignPagination: PropTypes.string,
+
+    /**
+     * set the available page sizes for the datagrid pagination
+     */
+    paginationPageSizes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
 };
 
 FKSelector.defaultProps = {

--- a/src/ui/FkSelectorModal.js
+++ b/src/ui/FkSelectorModal.js
@@ -43,7 +43,8 @@ const FkSelectorModal = fnObserver(
             searchTimeout,
             fkSelectorId,
             selectButtonContentRenderer,
-            alignPagination
+            alignPagination,
+            paginationPageSizes
         } = props;
 
         const formObject = useLocalObservable(() => observable({filter}));
@@ -203,6 +204,7 @@ const FkSelectorModal = fnObserver(
                                     value={ iQuery }
                                     filterTimeout={ searchTimeout }
                                     alignPagination={ alignPagination }
+                                    paginationPageSizes={paginationPageSizes}
                                     isCompact
                                 >
                                     <DataGrid.Column

--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -44,7 +44,19 @@ const COLUMN_CONFIG_INPUT_OPTS = {
  */
 const DataGrid = fnObserver(props => {
 
-    const { id, name, value, isCompact, tableClassName, rowClasses, filterTimeout, workingSet, alignPagination, children } = props;
+    const {
+        id,
+        name,
+        value,
+        isCompact,
+        tableClassName,
+        rowClasses,
+        filterTimeout,
+        workingSet,
+        alignPagination,
+        paginationPageSizes,
+        children
+    } = props;
 
     const [suppressFilter, internalQuery] = useMemo(() => {
         if (Array.isArray(value)) {
@@ -335,6 +347,7 @@ const DataGrid = fnObserver(props => {
                 iQuery={ internalQuery }
                 description={ i18n("Result Navigation") }
                 align={ alignPagination }
+                pageSizes={ paginationPageSizes }
             />
         </GridStateForm>
     );
@@ -375,6 +388,11 @@ DataGrid.propTypes = {
      * set the pagination alignment ("left" [default], "center", "right")
      */
     alignPagination: PropTypes.string,
+
+    /**
+     * set the available page sizes for the pagination
+     */
+    paginationPageSizes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
 };
 
 


### PR DESCRIPTION
Add pagination page size properties to DataGrid, FKSelector
and AssociationSelector to allow setting the page sizes
through application code.
Ticket: AUTO-159