### PR TITLE
Fix type handling in registerFKSelectorFilterAndRenderer

### DIFF
--- a/src/util/filter/registerFKSelectorFilter.js
+++ b/src/util/filter/registerFKSelectorFilter.js
@@ -5,6 +5,7 @@ import {registerCustomFilterRenderer} from "./CustomFilterRenderer";
 import {field, value} from "../../../filter";
 import {Field, useFormConfig} from "../../../../domainql-form";
 import {FKSelector} from "../../index";
+import config from "../../config";
 
 
 /**
@@ -28,13 +29,17 @@ export function registerFKSelectorFilterAndRenderer(name, query, rootType, sourc
 
     registerCustomFilterRenderer(name, (fieldName, fieldType, label) => {
         const formConfig = useFormConfig();
+        if (!fieldType) {
+            const fieldSchemaType = config.inputSchema.resolveType(rootType, sourceName);
+            fieldType = fieldSchemaType.ofType.name;
+        }
         return(<FKSelector
             name={fieldName}
             type={fieldType}
             label={label}
             query={query}
-            rootType={rootType}
-            sourceName={sourceName}
+            catalogueRootType={rootType}
+            catalogueFieldQualifiedName={sourceName}
             labelClass="sr-only"
             display={(formConfig, ctx) => {
                 const row = Field.getValue(formConfig, ctx);


### PR DESCRIPTION
Fix a bug where a missing type in registerCustomFilterRenderer would
crash the application instead of trying to resolve the type using the
given parameters.
Fix use renamed parameters instead of the old ones.