### PR TITLE
Remove computed (readonly) fields from WorkingSet

### DIFF
--- a/src/GraphQLQuery.js
+++ b/src/GraphQLQuery.js
@@ -1,7 +1,7 @@
 import parseQuery from "./parseQuery"
 import config from "./config"
 import graphql from "./graphql"
-import clone from "./util/clone"
+import cloneJSONObject from "./util/cloneJSONObject"
 
 
 /**
@@ -73,7 +73,7 @@ export default class GraphQLQuery {
      */
     clone()
     {
-        const c = new GraphQLQuery(this.query, clone(this.defaultVars))
+        const c = new GraphQLQuery(this.query, cloneJSONObject(this.defaultVars))
         c.queryDef = this.queryDef
         return c
     }

--- a/src/WorkingSet.js
+++ b/src/WorkingSet.js
@@ -17,6 +17,7 @@ import { MergeOperation } from "./merge/MergeOperation"
 import { openDialog } from "./util/openDialog"
 import toJSEveryThing from "./util/toJSEveryThing"
 import { getCurrentProcess } from "./process/Process"
+import { isPropertyWritable } from "domainql-form"
 
 
 const LIST_OF_DOMAIN_OBJECTS_TYPE = "[DomainObject]";
@@ -903,6 +904,10 @@ class EntityRegistration
         for (let i = 0; i < scalarFields.length; i++)
         {
             const {name, type} = scalarFields[i];
+
+            if(!isPropertyWritable(domainObject, name)) {
+                continue;
+            }
 
             const currValue = domainObject[name];
 

--- a/src/util/cloneJSONObject.js
+++ b/src/util/cloneJSONObject.js
@@ -5,14 +5,14 @@ import { isPropertyWritable } from "domainql-form"
  * 
  * @param {Object|Array|string|number|boolean} value value to clone
  */
-export default function clone(value)
+export default function cloneJSONObject(value)
 {
     if (Array.isArray(value))
     {
         const out = []
         for (let i = 0; i < value.length; i++)
         {
-            out[i] = clone(value[i])
+            out[i] = cloneJSONObject(value[i])
         }
         return out
     }
@@ -24,7 +24,7 @@ export default function clone(value)
             if (value.hasOwnProperty(prop))
             {
                 if(isPropertyWritable(out, prop)) {
-                    out[prop] = clone(value[prop])
+                    out[prop] = cloneJSONObject(value[prop])
                 }
             }
         }

--- a/test/util/clone.js
+++ b/test/util/clone.js
@@ -1,6 +1,6 @@
 import React from "react"
 import assert from "power-assert"
-import clone from "../../src/util/clone";
+import cloneJSONObject from "../../src/util/cloneJSONObject";
 
 import { field, value, values, and, or, not, condition, operation } from "../../src/FilterDSL";
 
@@ -10,7 +10,7 @@ describe("clone", function () {
 
         {
             const obj = { a : "Hello", b: "There", c: [1,2,3], d: true, e: 123}
-            const copy = clone(obj)
+            const copy = cloneJSONObject(obj)
 
             assert(obj !== copy)
             assert(obj.a === copy.a)
@@ -26,7 +26,7 @@ describe("clone", function () {
 
         {
             const obj = [1,{foo:"bar"}]
-            const copy = clone(obj)
+            const copy = cloneJSONObject(obj)
 
             assert(obj !== copy)
             assert(obj[0] === copy[0])


### PR DESCRIPTION
To fix a bug, where you can not save changes to the form properly
due to readonly fields being potential targets of editing, readonly
fields are now excluded from being written to the WorkingSet as changes.

Also the clone.js file solely used in automaton-js has been renamed to
enable actually debugging the domainql-form clone.js since they confused
the debuggers by being named exacly the same and residing in the same
spot in their respective repository.