### PR TITLE
issue/offline_query_from_array: Bugfix for empty type property in OfflineQuerys based on Arrays

### DIFF
--- a/src/model/OfflineQuery.js
+++ b/src/model/OfflineQuery.js
@@ -73,17 +73,23 @@ export default class OfflineQuery
                 "offset": 0
             };
             this.columnStates = [];
-            for (const columnName in source[0]) {
-                if (columnName != "_type") {
-                    this.columnStates.push({
-                        "_type": "ColumnState",
-                        "name": columnName,
-                        "sortable": true,
-                        "enabled": true
-                    });
+
+            const targetObject = source[0];
+            if(targetObject){
+                for (const columnName in targetObject) {
+                    if (columnName !== "_type") {
+                        this.columnStates.push({
+                            "_type": "ColumnState",
+                            "name": columnName,
+                            "sortable": true,
+                            "enabled": true
+                        });
+                    }
                 }
+                this.type = targetObject._type;
+            }else {
+                this.type = null;
             }
-            this.type = null;
             this._type = "OfflineQuery";
         } else if (source instanceof InteractiveQuery) {
             this.data = source.rows;


### PR DESCRIPTION
Fixed an issue with creating an OfflineQuery from an array. The type property in the query was not set properly, causing problems in datagrids with filters.