### PR TITLE
Add page size and sort to DataGrid user config

### DIFF
--- a/src/util/useEffectNoInitial.js
+++ b/src/util/useEffectNoInitial.js
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Helper to have a useEffect that runs only on changes after it was already initialized
+ */
+export default function useEffectNoInitial(effect, deps) {
+    
+    const active = useRef(false);
+
+    useEffect(() => {
+        if (active.current) {
+            return effect();
+        } else {
+            active.current = true;
+        }
+    }, deps);
+}


### PR DESCRIPTION
The tableConfig for DataGrids now accepts pageinationSize and sortColumn
as additional properties. Also the onTableConfigChange now returns
these values if they change internally.