### PR TITLE
Add searchFilter to AssociationSelector

### DIFF
--- a/src/ui/AssociationSelectorModal.js
+++ b/src/ui/AssociationSelectorModal.js
@@ -1,11 +1,21 @@
-import React from "react"
+import React, { useEffect, useMemo, useRef } from "react"
 import i18n from "../i18n";
 
 import { ButtonToolbar, Container, Modal, ModalBody, ModalHeader } from "reactstrap"
 import DataGrid from "./datagrid/DataGrid";
 import get from "lodash.get"
-import { observer as fnObserver } from "mobx-react-lite";
+import { useLocalObservable, observer as fnObserver } from "mobx-react-lite";
+import { action, comparer, observable, reaction } from "mobx";
+import { NO_FILTER, NO_SEARCH_FILTER, COLUMN_FILTER, createSearchFilter } from "./AssociationSelector";
+import { Addon, Field, Form, Icon } from "domainql-form";
+import updateComponentCondition from "../util/updateComponentCondition";
 
+const setFilter = action(
+    "FkSelectorModal.setFilter",
+    (formObject, filter) => {
+        formObject.filter = filter;
+    }
+)
 
 /**
  * Selector popup for the FK selector.
@@ -15,15 +25,93 @@ const AssociationSelectorModal = fnObserver(props => {
     const {
         isOpen,
         iQuery,
+        iQueryType,
         columns,
         title,
         toggle,
         fade,
+        filter = null,
+        modalFilter,
+        searchFilter,
+        searchTimeout,
         selected,
         idPath,
         alignPagination,
-        paginationPageSizes
+        paginationPageSizes,
+        associationSelectorId
     } = props;
+
+    const formObject = useLocalObservable(() => observable({filter}));
+
+    const iQueryRef = useRef(null);
+    const searchFieldRef = useRef(null);
+
+    useEffect(
+        () => {
+
+            // reinitialize filter on opening
+            if (isOpen && formObject.filter !== filter)
+            {
+                setFilter(formObject, filter);
+            }
+
+            // update iQuery ref
+            iQueryRef.current = iQuery;
+        }
+    )
+
+    const haveSearchFilter = !!searchFilter;
+    const showSearchFilter = haveSearchFilter && modalFilter !== NO_SEARCH_FILTER && modalFilter !== NO_FILTER;
+    const showColumnFilter = (!haveSearchFilter && modalFilter !== NO_FILTER) ||
+                                 (haveSearchFilter && modalFilter === NO_SEARCH_FILTER) ||
+                                 modalFilter === COLUMN_FILTER;
+
+    useEffect(
+        () => {
+            return reaction(
+                // the expression creates a new filter expression from the current observable state
+                () => {
+
+                    const { filter } = formObject;
+                    if (filter && showSearchFilter)
+                    {
+                        return createSearchFilter(iQueryType, searchFilter, formObject.filter);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+
+                },
+                // and the effect triggers the debounced condition update
+                newCondition => {
+
+                    const cachedVars = iQueryRef.current._query.vars;
+
+                    const currentCondition = iQueryRef.current._query.vars.config.condition;
+
+                    const composite = currentCondition != null ? updateComponentCondition(
+                        iQueryRef.current._query.vars.config.condition,
+                        newCondition,
+                        associationSelectorId
+                    ) : newCondition;
+
+                    // We can't use `iQuery` directly because this closure traps the very first iQuery prop value
+                    // which is always null. So we trap the iQueryRef ref instead and change its current prop
+                    iQueryRef.current.updateCondition(
+                        composite
+                    ).then(() => {
+                        iQueryRef.current._query.vars = cachedVars;
+                    });
+                },
+                {
+                    delay: searchTimeout,
+                    equals: comparer.structural
+                }
+            );
+        },
+        []
+    );
 
     return(
         <Modal isOpen={ isOpen } toggle={ toggle } size="lg" fade={ fade }>
@@ -36,12 +124,63 @@ const AssociationSelectorModal = fnObserver(props => {
             </ModalHeader>
             <ModalBody>
                 <Container fluid={ true }>
+                    <div className="row">
+                        <div className="col">
+                            {
+                                showSearchFilter && (
+                                    <Form
+                                        value={ formObject }
+                                        options={{
+                                        }}
+                                    >
+                                        <Field
+                                            ref={ searchFieldRef }
+                                            name="filter"
+                                            label="search"
+                                            labelClass="sr-only"
+                                            formGroupClass="mb-2"
+                                            type="String"
+                                        >
+                                            <Addon
+                                                placement={ Addon.LEFT }
+                                                text={ true }
+                                            >
+                                                <Icon className="fa-search"/>
+                                            </Addon>
+                                            <Addon
+                                                placement={ Addon.RIGHT }
+                                            >
+                                                <button
+                                                    className="btn btn-light border"
+                                                    type="button"
+                                                    onClick={
+                                                        () => {
+                                                            setFilter(formObject, "")
+                                                            searchFieldRef.current.focus()
+                                                        }
+                                                    }
+
+                                                >
+
+                                                    <Icon className="fa-eraser mr-1"/>
+                                                    {
+                                                        i18n("Clear")
+                                                    }
+                                                </button>
+                                            </Addon>
+                                        </Field>
+                                    </Form>
+                                )
+                            }
+                        </div>
+                    </div>
                     {
                         isOpen && (
                             <DataGrid
                                 id="fk-selector-grid"
                                 tableClassName="table-hover table-striped table-bordered table-sm"
                                 value={ iQuery }
+                                filterTimeout={ searchTimeout }
                                 alignPagination={ alignPagination }
                                 paginationPageSizes={ paginationPageSizes }
                                 isCompact
@@ -65,7 +204,18 @@ const AssociationSelectorModal = fnObserver(props => {
                                                 key={ name }
                                                 name={ name }
                                                 heading={ heading }
-                                                filter="containsIgnoreCase"
+                                                filter={
+                                                    showColumnFilter ? (
+                                                        columnTypes[idx] === "String" ?
+                                                            "containsIgnoreCase" :
+                                                            (fieldName, val) =>
+                                                                field(name).toString()
+                                                                .containsIgnoreCase(
+                                                                    value(val, "String")
+                                                                )
+                                                        ) :
+                                                        null
+                                                }
                                             />
                                         )
                                     )


### PR DESCRIPTION
Implement searchFilter for AssociationSelector working the same as the
ones of the FKSelector.
Adds the searchbar on top of the modal, and allows control over what
filter type to render.
Can be used, as known from FKSelector, to counter errors from computed
fields.