### PR TITLE
Add dependency resolver  and add it to DataGrid

### DIFF
--- a/src/ui/datagrid/Column.js
+++ b/src/ui/datagrid/Column.js
@@ -5,13 +5,24 @@ import cx from "classnames"
 import { GlobalConfig, useFormConfig } from "domainql-form"
 import { observer as fnObserver } from "mobx-react-lite"
 import { lookupType, unwrapNonNull } from "../../util/type-utils";
+import { resolveFieldDependencies, resolveFieldDependenciesValue } from "../../util/dependencyUtilities";
 
 /**
  * DataGrid column component
  */
 const Column = fnObserver(props => {
 
-    const { name, context, width, minWidth, maxWidth, nobreak, className, children} = props;
+    const {
+        name,
+        context,
+        workingSet,
+        width,
+        minWidth,
+        maxWidth,
+        nobreak,
+        className,
+        children
+    } = props;
 
     const formConfig = useFormConfig();
     const rowErrors = formConfig.formContext.getErrorsForRoot(context);
@@ -75,7 +86,7 @@ const Column = fnObserver(props => {
         )
     }
     
-    const value = isInvalid ? fieldError[0] : get(context, name);
+    const value = isInvalid ? fieldError[0] : resolveFieldDependenciesValue(workingSet, context, name);
 
     const renderedValue = value === null || value === undefined || value === "" ?
         GlobalConfig.none() :

--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -23,6 +23,7 @@ import OfflineQuery from "../../model/OfflineQuery";
 import UserColumnConfigDialogModal from "./userconfig/UserColumnConfigDialogModal";
 import DataGridButtonToolbar from "./DataGridButtonToolbar";
 import useEffectNoInitial from "../../util/useEffectNoInitial"
+import { resolveTableDependencies } from "../../util/dependencyUtilities"
 
 
 function findColumn(columnStates, name)
@@ -290,6 +291,14 @@ const DataGrid = fnObserver(props => {
     );
     const [records, setRecords] = React.useState([]);
 
+    const viewDependencies = resolveTableDependencies(type);
+    const newWorkingSetObjects = useMemo(() => {
+        return workingSet ? [
+            ...workingSet.newObjects(type),
+            ...viewDependencies?.map((dependency) => workingSet.newObjects(dependency)).flat() ?? []
+        ] : []
+    }, [workingSet?.newObjects()]);
+
     useEffect(() => {
         const sortedRows = sortByField(rows, moveRowColumn).map(
             (context) => {
@@ -321,10 +330,11 @@ const DataGrid = fnObserver(props => {
         
                 const filterFn = filterTransformer(queryConfig.condition, fieldResolver.resolve);
         
-                const newObjects = workingSet.newObjects(type);
-                return newObjects.filter( obj => {
-                    fieldResolver.current = obj;
-                    return filterFn();
+                return newWorkingSetObjects.filter( obj => {
+                    if (obj._type === type) {
+                        return filterFn();
+                    }
+                    return true;
                 }).map(context => [context, null]);
             })() || []),
             ...sortedRows
@@ -333,7 +343,7 @@ const DataGrid = fnObserver(props => {
         setRecords(result);
     }, [
         rows,
-        workingSet?.newObjects(type),
+        newWorkingSetObjects,
         workingSet?.changes
     ]);
 
@@ -507,6 +517,7 @@ const DataGrid = fnObserver(props => {
                                                     key={ idx }
                                                     idx={ idx }
                                                     context={ context }
+                                                    workingSet={ workingSet }
                                                     columns={ columns }
                                                     moveRow={ moveRow }
                                                     dropRow={ dropRow }

--- a/src/ui/datagrid/rows/DataRow.js
+++ b/src/ui/datagrid/rows/DataRow.js
@@ -6,6 +6,7 @@ import { Icon, useFormConfig } from "domainql-form";
 const DataRow = ({
     idx,
     context,
+    workingSet,
     columns,
     moveRowColumn,
     moveRow,
@@ -89,7 +90,8 @@ const DataRow = ({
                                     column.columnElem,
                                     {
                                         key: columnIdx,
-                                        context
+                                        context,
+                                        workingSet
                                     }
                                 );
                             }

--- a/src/util/dependencyUtilities.js
+++ b/src/util/dependencyUtilities.js
@@ -1,0 +1,71 @@
+import get from "lodash.get";
+import config from "../config";
+
+/**
+ * Recursively resolve the view dependencies for a table definition
+ * 
+ * @param {string} type the table for which to find the dependencies
+ * @returns {string[]} all found dependencies as a flattened array in detection order
+ */
+export function resolveTableDependencies(type) {
+    const dependencyMeta = config.inputSchema.getTypeMeta(type, "dependency");
+    if (!dependencyMeta) {
+        return null;
+    }
+    const dependencyList = dependencyMeta.split(",");
+    const result = dependencyList.map((dependencyType) => {
+        return resolveTableDependencies(dependencyType) ?? dependencyType;
+    });
+    return result.flat().filter((item, pos, self) => {
+        return self.indexOf(item) === pos;
+    });
+}
+
+/**
+ * Recursively resolve the view dependencies for a field definition
+ * 
+ * @param {string} type the table where the field is defined in
+ * @param {string} name the name of the field in the table
+ * @returns {string[]} all found dependencies as a flattened array in detection order
+ */
+export function resolveFieldDependencies(type, name) {
+    const dependencyMeta = config.inputSchema.getFieldMeta(type, name, "dependency");
+    if (!dependencyMeta) {
+        return null;
+    }
+    const dependencyList = dependencyMeta.split(",");
+    const result = dependencyList.map((dependency) => {
+        const [dependencyType, dependencyName] = dependency.split(".");
+        return resolveFieldDependencies(dependencyType, dependencyName) ?? dependency;
+    });
+    return result.flat().filter((item, pos, self) => {
+        return self.indexOf(item) === pos;
+    });
+}
+
+/**
+ * Recursively resolve the view dependencies for a field definition and look into the workingset to find a
+ * changed value for the dependencies if it exists
+ * 
+ * @param {WorkingSet} workingSet the workingset to look into for dependency values
+ * @param {FormContext} context the formcontext of the current value holder
+ * @param {string} name the name of the field in the table
+ * @returns if there is a value for one depency in the workingset the workingset value, else the value in
+ *          the context
+ */
+export function resolveFieldDependenciesValue(workingSet, context, name) {
+    const dependencies = resolveFieldDependencies(context._type, name);
+    if (dependencies != null) {
+        if (workingSet) {
+            for (const dependency of dependencies) {
+                const [dependencyType, dependencyName] = dependency.split(".");
+                const entry = workingSet.lookup(dependencyType, context.id);
+                if (entry && entry.changes.has(dependencyName)) {
+                    const value = entry.changes.get(dependencyName).value;
+                    return value;
+                }
+            }
+        }
+    }
+    return get(context, name);
+}

--- a/src/util/dependencyUtilities.js
+++ b/src/util/dependencyUtilities.js
@@ -55,15 +55,12 @@ export function resolveFieldDependencies(type, name) {
  */
 export function resolveFieldDependenciesValue(workingSet, context, name) {
     const dependencies = resolveFieldDependencies(context._type, name);
-    if (dependencies != null) {
-        if (workingSet) {
-            for (const dependency of dependencies) {
-                const [dependencyType, dependencyName] = dependency.split(".");
-                const entry = workingSet.lookup(dependencyType, context.id);
-                if (entry && entry.changes.has(dependencyName)) {
-                    const value = entry.changes.get(dependencyName).value;
-                    return value;
-                }
+    if (dependencies != null && workingSet) {
+        for (const dependency of dependencies) {
+            const [dependencyType, dependencyName] = dependency.split(".");
+            const entry = workingSet.lookup(dependencyType, context.id);
+            if (entry && entry.changes.has(dependencyName)) {
+                return entry.changes.get(dependencyName).value;
             }
         }
     }


### PR DESCRIPTION
DataGrid data might depend on other data based on views, etc. To effectively resolve the data on local changes to be directly visible inside the view without uploading, we add dependency metadata and a resolver utility to check recursively if any dependencies can be found. These dependencies are used to update any DataGrid with dependent data.