### PR TITLE
Fix FKSelector not updating after clearing

### DIFF
--- a/src/ui/FKSelector.js
+++ b/src/ui/FKSelector.js
@@ -412,6 +412,7 @@ const FKSelector = fnObserver(props => {
                                     const { root, formContext } = formConfig;
 
                                     formContext.updateErrors(root, ctx.qualifiedName, [ val, formConfig.formContext.getRequiredErrorMessage(ctx) ]);
+                                    setUserIsTyping(false);
                                     return;
                                 }
 


### PR DESCRIPTION
The FKSelector will now properly reset the isUserInput-flag when a validation error occurs after deleting its field content.