### PR TITLE
Add fieldData and rootType to render data object

### DIFF
--- a/src/ui/condition/ConditionEditor.js
+++ b/src/ui/condition/ConditionEditor.js
@@ -19,6 +19,7 @@ import PropTypes from "prop-types";
 import { runInAction } from "mobx";
 import ExpressionDialog from "./ExpressionDialog";
 import ExpressionDropdown from "./ExpressionDropdown";
+import { getFieldByPath } from "../../util/inputSchemaUtilities";
 
 
 function minXOfChildren(layoutNode)
@@ -91,12 +92,24 @@ const ConditionEditor = observer(function ConditionEditor(props) {
         className,
         options,
         formContext = FormContext.getDefault(),
-        valueRenderer,
+        valueRenderer: valueRendererFromProps,
         schemaResolveFilterCallback,
         onChange,
         hideImportExport: enableImportExport,
         queryCondition: queryConditionFromProps
     } = props;
+
+    const valueRenderer = useMemo(() => {
+        if (typeof valueRendererFromProps === "function") {
+            return (pathName, nodeData = {}) => {
+                return valueRendererFromProps(pathName, {
+                    ...nodeData,
+                    rootType,
+                    fieldData: getFieldByPath(rootType, pathName)
+                });
+            }
+        }
+    }, [valueRendererFromProps]);
 
     const onConditionChange = () => {
         const queryCondition = get(container, containerPath);

--- a/src/ui/queryeditor/QueryEditor.js
+++ b/src/ui/queryeditor/QueryEditor.js
@@ -2,14 +2,13 @@ import React, {useEffect, useMemo, useState} from "react";
 import i18n from "../../i18n";
 import ConditionEditor from "../condition/ConditionEditor";
 import cx from "classnames";
-import flattenObject from "../../util/flattenObject";
 import SortColumnList from "./SortColumnList";
 import ConditionEditorScope from "./ConditionEditorScope";
 import {FormContext, Icon} from "domainql-form";
 import {ButtonToolbar} from "reactstrap";
 import ColumnSelect from "./ColumnSelect";
 import PropTypes from "prop-types";
-import { createTreeRepresentationForInputSchema } from "../../util/inputSchemaUtilities";
+import { getFieldByPath } from "../../util/inputSchemaUtilities";
 
 const ORIGINS = {
     CONDITION_EDITOR_FIELD_SELECTION: "ConditionEditorFieldSelection",
@@ -30,28 +29,21 @@ const QueryEditor = (props) => {
         className
     } = props;
 
-    // scope
-    const [
-        conditionEditorScope,
-        availableColumnTreeObject,
-        availableColumnList
-    ] = useMemo(() => {
-        const availableColumnTreeObject = createTreeRepresentationForInputSchema(rootType, {
-            filterCallback: schemaResolveFilterCallback
-        });
-        const availableColumnList = Object.keys(flattenObject(availableColumnTreeObject)).map((element) => {
-            return {
-                name: element,
-                label: columnNameRenderer ? columnNameRenderer(element, {
-                    origin: ORIGINS.CONDITION_EDITOR_FIELD_SELECTION
-                }) : element
+    const valueRenderer = useMemo(() => {
+        if (typeof columnNameRenderer === "function") {
+            return (pathName, nodeData = {}) => {
+                return columnNameRenderer(pathName, {
+                    ...nodeData,
+                    rootType,
+                    fieldData: getFieldByPath(rootType, pathName)
+                });
             }
-        });
-        return [
-            new ConditionEditorScope(rootType),
-            availableColumnTreeObject,
-            availableColumnList
-        ];
+        }
+    }, [columnNameRenderer]);
+
+    // scope
+    const conditionEditorScope = useMemo(() => {
+        return new ConditionEditorScope(rootType);
     }, [rootType]);
 
     // data states
@@ -92,7 +84,7 @@ const QueryEditor = (props) => {
                     <ColumnSelect
                         rootType={rootType}
                         selectedColumns={selectedColumns}
-                        valueRenderer={columnNameRenderer}
+                        valueRenderer={valueRenderer}
                         onChange={(tokenList) => {
                             setSelectedColumns(tokenList);
                         }}
@@ -116,7 +108,7 @@ const QueryEditor = (props) => {
                 <div className="card-body border-top">
                     <SortColumnList
                         rootType={rootType}
-                        valueRenderer={columnNameRenderer}
+                        valueRenderer={valueRenderer}
                         sortColumns={sortColumns}
                         onChange={(sortColumnList) => {
                             setSortColumns(sortColumnList);

--- a/src/util/inputSchemaUtilities.js
+++ b/src/util/inputSchemaUtilities.js
@@ -70,6 +70,11 @@ export function createTreeRepresentationForInputSchemaByPath(rootType, schemaPat
     return {};
 }
 
+export function getFieldByPath(rootType, pathName) {
+    const inputSchema = config.inputSchema;
+    return findFieldByPath(inputSchema, rootType, pathName);
+}
+
 function recursiveCreateTreeRepresentationForObject(inputSchema, schemaPath, fieldPath, filterCallback, recursive) {
     const splitPath = schemaPath.split(".");
     const tableName = splitPath.at(-1);
@@ -89,7 +94,8 @@ function recursiveCreateTreeRepresentationForObject(inputSchema, schemaPath, fie
             fieldPath: newFieldPath,
             schemaPath: newSchemaPath,
             currentName: fieldName,
-            currentType: unwrappedName
+            currentType: unwrappedName,
+            tableName: table.name
         };
         if (typeof filterCallback === "function" && !filterCallback(filterCallbackData)) {
             continue;
@@ -137,6 +143,22 @@ function findSchemaObjectByName(inputSchema, name) {
     return inputSchema.schema.types.find(current => {
         return current.name === name;
     });
+}
+
+function findFieldByPath(inputSchema, rootType, pathName) {
+    const path = pathName.split(".");
+    const name = path.shift();
+    if (name) {
+        const table = findSchemaObjectByName(inputSchema, rootType);
+        const field = findFieldObjectByName(table, name);
+        if (path.length === 0) {
+            return field;
+        }
+        const {kind: unwrappedKind, name: unwrappedName} = unwrapAll(field.type);
+        if (unwrappedKind === "OBJECT") {
+            return findFieldByPath(inputSchema, unwrappedName, path.join("."));
+        }
+    }
 }
 
 function findFieldObjectByName(table, name) {


### PR DESCRIPTION
For easier renderer function implementation the data object for the value renderer in QueryEditor / ConditionEditor now includes the rootType and fieldData properties.