### PR TITLE
Fix load of columnselection for DataGrid in dialog

### DIFF
--- a/src/ui/datagrid/userconfig/UserColumnConfigDialogModal.js
+++ b/src/ui/datagrid/userconfig/UserColumnConfigDialogModal.js
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {ButtonToolbar, Modal, ModalBody, ModalHeader} from "reactstrap";
 import i18n from "../../../i18n";
 import DualListSelector from "../../listselector/DualListSelector";
@@ -16,6 +16,14 @@ const UserColumnConfigDialogModal = (props) => {
 
     const [currentInactiveElements, setCurrentInactiveElements] = useState(inactiveElements);
     const [currentActiveElements, setCurrentActiveElements] = useState(activeElements);
+
+    useEffect(() => {
+        setCurrentInactiveElements(inactiveElements);
+    }, [inactiveElements]);
+
+    useEffect(() => {
+        setCurrentActiveElements(activeElements);
+    }, [activeElements]);
 
     function doSubmit() {
         onSubmit(currentActiveElements);

--- a/src/ui/listselector/SelectionList.js
+++ b/src/ui/listselector/SelectionList.js
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from "react";
+import React, {useMemo, useRef, useState} from "react";
 import cx from "classnames";
 import i18n from "../../i18n";
 import {Icon} from "domainql-form";
@@ -14,7 +14,7 @@ function elementComparator(element0, element1) {
 const SelectionList = (props) => {
     const {
         header,
-        elements,
+        elements: elementsFromProps,
         selected,
         autoSort,
         onChange,
@@ -35,16 +35,21 @@ const SelectionList = (props) => {
         onChange(element);
     }
 
-    const filteredElements = searchValue !== ""
-        ? elements.filter((element) => {
-            const elementValue = element.label ?? element.name;
-            return elementValue?.toLowerCase().includes(searchValue) ?? false;
-        })
-        : elements;
-
-    const sortedElements = autoSort
-        ? filteredElements.sort(elementComparator)
-        : filteredElements;
+    const elements = useMemo(() => {
+        if (searchValue !== "") {
+            const filteredElements = elementsFromProps.filter((element) => {
+                const elementValue = element.label ?? element.name;
+                return elementValue?.toLowerCase().includes(searchValue) ?? false;
+            });
+            if (autoSort) {
+                return filteredElements.sort(elementComparator);
+            }
+            return filteredElements;
+        } else if (autoSort) {
+            return elementsFromProps.sort(elementComparator)
+        }
+        return elementsFromProps;
+    }, [elementsFromProps, searchValue, autoSort]);
 
     return (
         <div className="d-flex flex-column flex-fill m-4 selection-list-container">
@@ -86,9 +91,9 @@ const SelectionList = (props) => {
             <div className="d-flex flex-row flex-fill">
                 <ul className="flex-fill selection-list list-group border rounded">
                     {
-                        sortedElements.length < 1
+                        elements.length < 1
                             ? (<span className="m-2 font-italic">{i18n("No Elements")}</span>)
-                            : sortedElements.map((element, index) => {
+                            : elements.map((element, index) => {
                                 return (
                                     <li
                                         key={index}


### PR DESCRIPTION
Fix the UserColumnConfigDialogModal to allow setting the selected columns after the initial load. This was a visual bug reducing usability of the feature.