### PR TITLE
Substitute a template literal in jsx

### DIFF
--- a/src/ui/queryeditor/SortColumnListElement.js
+++ b/src/ui/queryeditor/SortColumnListElement.js
@@ -26,7 +26,7 @@ const SortColumnListElement = (props) => {
                 type="Button"
                 className="btn btn-link m-0 p-0"
                 title={
-                    i18n(`QueryEditor:Toggle Order; Current: ${order === "A" ? "Ascending" : "Descending"}`)
+                    i18n("QueryEditor:Toggle Order; Current: " + (order === "A" ? "Ascending" : "Descending"))
                 }
                 onClick={
                     () => toggleElementOrder(sortColumnElement)


### PR DESCRIPTION
To remove an error in the build process, at least in jsx substitute a template literal with the old school string concatenation method.