### PR TITLE
Add dynamic translated component

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ import {
     COMMON_SCOPE
 } from "./scopeNames"
 import i18n from "./i18n";
+import { observable } from "mobx";
 
 export const DEFAULT_OPTS = {
 
@@ -19,7 +20,7 @@ export const DEFAULT_OPTS = {
     auth: null,
 
     locale: null,
-    translations: {},
+    translations: observable({}),
     markUntranslated: true,
 
     mergeOptions: {
@@ -120,7 +121,7 @@ function applyDefaults(theConfig)
 
 
 const VALID_KEYS = Object.keys(DEFAULT_OPTS);
-
+const OBSERVABLE_PROPERTIES = ["translations"];
 
 /**
  * Adds a new config name and value to the global config object and also adds that name to the list of valid option
@@ -158,7 +159,11 @@ const theConfig = new Proxy(
 
             ensureValid(property);
 
-            config[property] = value;
+            if (OBSERVABLE_PROPERTIES.includes(property)) {
+                config[property] = observable(value);
+            } else {
+                config[property] = value;
+            }
 
             return true;
         },
@@ -169,6 +174,7 @@ const theConfig = new Proxy(
     }
 );
 
+window.appConfig = theConfig;
 applyDefaults(theConfig);
 export default theConfig;
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import config from "./config";
 import { Process, getCurrentProcess, confirmDestructiveTransition } from "./process/Process"
 import runProcess, { runProcessURI } from "./process/runProcess";
 
+import I18nTranslation from "./ui/I18nTranslation";
 import DataGrid from "./ui/datagrid/DataGrid"
 import Button from "./ui/Button"
 import Link from "./ui/Link"
@@ -110,6 +111,7 @@ export {
     Process,
     getCurrentProcess,
     // UI components
+    I18nTranslation,
     DataGrid,
     Pagination,
     Button,

--- a/src/ui/I18nTranslation.js
+++ b/src/ui/I18nTranslation.js
@@ -1,0 +1,44 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { observer as fnObserver } from "mobx-react-lite";
+import config from "../config";
+import i18n from "../i18n";
+
+/**
+ * Dynamic i18n component to "liveload" translation values
+ */
+const I18nTranslation = fnObserver((props) => {
+    
+    const { value, args = [], renderer } = props;
+
+    const translation = useMemo(() => {
+        return i18n(value, ...args);
+    }, [config.translations, value, args]);
+
+    if (typeof renderer === "function") {
+        return renderer(translation);
+    }
+
+    return translation;
+});
+
+I18nTranslation.propTypes = {
+
+    /**
+     * translation tag/key
+     */
+    value: PropTypes.string.isRequired,
+
+    /**
+     * optional translation parameters
+     */
+    args: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+
+    /**
+     * optional renderer to modify the result by e.g. wrapping it in an "option"-element
+     */
+    renderer: PropTypes.func
+
+};
+
+export default I18nTranslation;

--- a/src/ui/Pagination.js
+++ b/src/ui/Pagination.js
@@ -1,7 +1,7 @@
 import React from "react"
 import cx from "classnames"
 import { observer as fnObserver } from "mobx-react-lite"
-import i18n from "../i18n";
+import I18nTranslation from "./I18nTranslation";
 
 
 export const DEFAULT_PAGE_SIZES = [
@@ -9,13 +9,13 @@ export const DEFAULT_PAGE_SIZES = [
     10,
     20,
     50,
-    i18n("All Rows")
+    "All Rows"
 ];
 
-const BUTTON_FIRST = i18n("Pagination:First");
-const BUTTON_PREV = i18n("Pagination:Prev");
-const BUTTON_NEXT = i18n("Pagination:Next");
-const BUTTON_LAST = i18n("Pagination:Last");
+const BUTTON_FIRST = <I18nTranslation value="Pagination:First" />;
+const BUTTON_PREV = <I18nTranslation value="Pagination:Prev" />;
+const BUTTON_NEXT = <I18nTranslation value="Pagination:Next" />;
+const BUTTON_LAST = <I18nTranslation value="Pagination:Last" />;
 
 function getJustifyContentClass(align) {
     switch (align) {
@@ -115,9 +115,7 @@ const PageSizeSelect = props =>
         <label className="form-group input-group">
             <div className="input-group-prepend">
                 <span className="input-group-text">
-                    {
-                        i18n("Available Page Sizes")
-                    }
+                    <I18nTranslation value="Available Page Sizes" />
                 </span>
             </div>
             <select className="form-control page-size-select" value={pageSize} onChange={changePageSize}>
@@ -126,7 +124,21 @@ const PageSizeSelect = props =>
 
                         const pageSize = getPageSize(value);
 
-                        return (
+                        return typeof value === "string" ? (
+                            <I18nTranslation
+                                key={idx}
+                                value={value}
+                                renderer={(translation) => (
+                                    <option
+                                        value={pageSize}
+                                    >
+                                        {
+                                            translation
+                                        }
+                                    </option>
+                                )}
+                            />
+                        ) : (
                             <option
                                 key={idx}
                                 value={pageSize}
@@ -152,9 +164,7 @@ const RowCountDisplay = props =>
         <div className="ml-2 form-group input-group">
             <div className="input-group-prepend">
                 <span className="input-group-text">
-                    {
-                        i18n("Row Count")
-                    }
+                    <I18nTranslation value="Row Count" />
                 </span>
             </div>
             <div className="input-group-append">


### PR DESCRIPTION
To ensure translations are properly applied, even if the component is created before the translation is loaded, a dynamically translated component is needed.
This new component will automatically update its translation if either the value (translation key), the translation arguments, the renderer or the translation itself changes.
The renderer is optionally added to change the resulting output, which is simply the text by default.