### PR TITLE
Streamline parameters used in QueryEditor

### DIFF
--- a/src/ui/queryeditor/QueryEditor.js
+++ b/src/ui/queryeditor/QueryEditor.js
@@ -99,10 +99,7 @@ const QueryEditor = (props) => {
                     onChange({
                         select: queryColumns ?? [],
                         where: queryCondition,
-                        sort: querySort?.map((sortColumnElement) => {
-                            const {name, order} = sortColumnElement;
-                            return `${order === "D" ? "!" : ""}${name}`;
-                        }) ?? []
+                        sort: querySort ?? []
                     });
                 }
             };
@@ -111,7 +108,7 @@ const QueryEditor = (props) => {
     });
 
     useEffect(() => {
-        const queryColumns = queryConfiguration?.columns ?? [];
+        const queryColumns = queryConfiguration?.select ?? [];
         const querySort = queryConfiguration?.sort?.map((element) => {
             const isDescending = element.startsWith("!");
             if (isDescending) {
@@ -125,9 +122,6 @@ const QueryEditor = (props) => {
 
         setSelectedColumns(queryColumns);
         setSortColumns(querySort);
-
-        editorState.setSelected(queryColumns);
-        editorState.setSort(querySort);
     }, [queryConfiguration]);
 
     const columnErrorMessages = formContext.findError(editorState.container, selectedColumnsPath.join("."));
@@ -174,7 +168,7 @@ const QueryEditor = (props) => {
                         path={queryConditionPath.join(".")}
                         valueRenderer={columnNameRenderer}
                         formContext={formContext}
-                        queryCondition={queryConfiguration?.condition}
+                        queryCondition={queryConfiguration?.where}
                         onChange={() => {
                             onQueryChange();
                         }}
@@ -188,7 +182,10 @@ const QueryEditor = (props) => {
                         valueRenderer={valueRenderer}
                         sortColumns={sortColumns ?? []}
                         onChange={(sortColumns) => {
-                            editorState.setSort(sortColumns);
+                            editorState.setSort(sortColumns.map((sortColumnElement) => {
+                                const {name, order} = sortColumnElement;
+                                return `${order === "D" ? "!" : ""}${name}`;
+                            }) ?? []);
                             setSortColumns(sortColumns);
                             onQueryChange();
                         }}

--- a/src/ui/queryeditor/QueryEditor.js
+++ b/src/ui/queryeditor/QueryEditor.js
@@ -26,20 +26,18 @@ const QueryEditor = (props) => {
         header,
         columnNameRenderer,
         formContext = FormContext.getDefault(),
-        path : containerPath = "",
         rootType,
-        container,
         saveButtonText,
         saveButtonOnClick,
         onChange,
-        queryConfiguration,
+        queryConfiguration = {},
         schemaResolveFilterCallback,
         className
     } = props;
 
-    const selectedColumnsPath = toPath(containerPath).concat(toPath("columns"));
-    const queryConditionPath = toPath(containerPath).concat(toPath("condition"));
-    const sortColumnsPath = toPath(containerPath).concat(toPath("sort"));
+    const selectedColumnsPath = toPath("select");
+    const queryConditionPath = toPath("where");
+    const sortColumnsPath = toPath("sort");
 
     const valueRenderer = useMemo(() => {
         if (typeof columnNameRenderer === "function") {
@@ -56,7 +54,7 @@ const QueryEditor = (props) => {
     }, [columnNameRenderer, rootType]);
 
     const editorState = useLocalObservable(() => {
-        return new QueryEditorState(rootType, container, containerPath);
+        return new QueryEditorState(rootType, queryConfiguration, "");
     });
 
     useEffect(() => {
@@ -81,7 +79,7 @@ const QueryEditor = (props) => {
                 kind: "LIST"
             }
         });
-    }, [editorState.container, containerPath]);
+    }, [editorState.container]);
 
     const [selectedColumns, setSelectedColumns] = useState([]);
     const [sortColumns, setSortColumns] = useState([]);
@@ -99,8 +97,8 @@ const QueryEditor = (props) => {
                     const queryCondition = get(container, queryConditionPath);
                     const querySort = get(container, sortColumnsPath);
                     onChange({
-                        columns: queryColumns ?? [],
-                        condition: queryCondition,
+                        select: queryColumns ?? [],
+                        where: queryCondition,
                         sort: querySort?.map((sortColumnElement) => {
                             const {name, order} = sortColumnElement;
                             return `${order === "D" ? "!" : ""}${name}`;
@@ -205,6 +203,7 @@ const QueryEditor = (props) => {
                                     type="Button"
                                     className="btn btn-primary"
                                     onClick={() => {
+                                        const queryCondition = get(editorState.container, queryConditionPath);
                                         const queryConfiguration = {
                                             select: selectedColumns,
                                             where: queryCondition,
@@ -261,16 +260,6 @@ QueryEditor.propTypes = {
      * defaults to the default FormContext
      */
     formContext: PropTypes.instanceOf(FormContext),
-    
-    /**
-     * container object to save the data into
-     */
-    container: PropTypes.object.isRequired,
-
-    /**
-     * path used by the editor
-     */
-    path : PropTypes.string.isRequired,
 
     /**
      * root type used by the editor

--- a/src/ui/queryeditor/QueryEditor.js
+++ b/src/ui/queryeditor/QueryEditor.js
@@ -126,7 +126,7 @@ const QueryEditor = (props) => {
         setSelectedColumns(queryColumns);
         setSortColumns(querySort);
 
-        editorState.setColumns(queryColumns);
+        editorState.setSelected(queryColumns);
         editorState.setSort(querySort);
     }, [queryConfiguration]);
 
@@ -153,7 +153,7 @@ const QueryEditor = (props) => {
                         selectedColumns={selectedColumns ?? []}
                         valueRenderer={valueRenderer}
                         onChange={(selectedColumns) => {
-                            editorState.setColumns(selectedColumns);
+                            editorState.setSelected(selectedColumns);
                             setSelectedColumns(selectedColumns);
                             onQueryChange();
                         }}

--- a/src/ui/queryeditor/QueryEditorState.js
+++ b/src/ui/queryeditor/QueryEditorState.js
@@ -47,10 +47,10 @@ export default class QueryEditorState {
     }
 
     @action
-    setColumns(columns) {
+    setSelected(columns) {
         const {container, containerPath} = this;
 
-        const p = toPath(containerPath).concat(toPath("columns"));
+        const p = toPath(containerPath).concat(toPath("select"));
         if (Array.isArray(columns) && columns.length > 0) {
             set(container, p, columns);
         } else {


### PR DESCRIPTION
Path and container where practically useless.
Use queryConfiguration to store internal data and make it truly optional by adding a default value to it.
Also change the return values of callbacks to use "select", "where" and "sort" instead of "columns", "condition" and "sort".