### PR TITLE
Add custom dependency resolver

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,8 @@ import ConditionEditor from "./ui/condition/ConditionEditor"
 import {unwrapNonNull, unwrapAll} from "./util/type-utils";
 import decompileFilter from "./util/decompileFilter"
 
+import { registerCustomDependencyResolver } from "./util/dependencyUtilities";
+
 import { registerCustomFilter } from "./util/filter/CustomFilter"
 import { registerCustomFilterRenderer } from "./util/filter/CustomFilterRenderer"
 import { registerFKSelectorFilterAndRenderer } from "./util/filter/registerFKSelectorFilter"
@@ -215,6 +217,8 @@ export {
     unwrapNonNull,
     unwrapAll,
     decompileFilter,
+
+    registerCustomDependencyResolver,
 
     registerCustomFilter,
     registerCustomFilterRenderer,

--- a/src/model2js/handleModelToJs.js
+++ b/src/model2js/handleModelToJs.js
@@ -204,7 +204,7 @@ export default query(
 
 export const renderStateScript = (state) => {
     let stateScript = ''
-    const {name, composite, transitionMap, filterFunctions} = state
+    const {name, composite, transitionMap, filterFunctions, customFunctions} = state
 
     stateScript += `
     const ${name} = new ViewState("${name}", (process, scope) => {
@@ -224,6 +224,15 @@ export const renderStateScript = (state) => {
             ${nameOfFilterFunctions} (${name}, ${query}, ${rootType}, ${sourceName}, ${modalTitle}, ${valueFieldName});
     `
             })
+        });
+    }
+
+    if (customFunctions) {
+        customFunctions.forEach(customFn => {
+            const {name, params} = customFn
+                stateScript += `
+            ${name} (${params.join(", ")});
+    `
         });
     }
 


### PR DESCRIPTION
Add a function to register custom dependency resolvers.
Also change modelToJs to allow defining custom functions in views with a variable number of parameters.

Usage registerCustomDependencyResolver:
registerCustomDependencyResolver(type, name, callbackFn);
type - the table name containing the column
name - the column name which should be resolved
callbackFn - the custom resolver (further information after this)

Where callbackFn:
function resolver(rowId, workingSet, currentValue) { 
    // ... do stuff and return a value to render
}
rowId - the current id of the row being resolved
workingSet - the workingset holds all changes of the current scope
currentValue - the value predetermined by the DataGrid

example:
registerCustomDependencyResolver("ABst", "asName", myCustomResolver);
function myCustomResolver(rowId, workingSet, currentValue) {
    // ... resolve from workingSet
    // fallback value
    return currentValue;
}