### PR TITLE
Fix doubling of columns without tableConfig

### DIFF
--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -289,9 +289,6 @@ const DataGrid = fnObserver(props => {
                 } else if (name) {
                     namedColumns.push({name, label: heading});
                     columnMap.set(name, column);
-                    if (visibleColumnsNotSet) {
-                        columns.push(column);
-                    }
                 } else {
                     columns.push(column);
                 }


### PR DESCRIPTION
Fix a bug where, if the tableConfig was not set, the columns would be added twice resulting in duplicated columns in the view.