### PR TITLE
USe domain object id to identify section fields

### DIFF
--- a/src/ui/shortcut/ShortcutItem.js
+++ b/src/ui/shortcut/ShortcutItem.js
@@ -6,7 +6,7 @@ import i18n from "../../i18n";
 import { WorkingSetStatus } from "../../WorkingSet";
 
 function isElementInSection(fieldEl, reference) {
-    if (fieldEl != null) {
+    if (fieldEl != null && !fieldEl.disabled) {
         if (fieldEl.dataset.section) {
             return fieldEl.dataset.section === reference;
         } else {
@@ -66,12 +66,12 @@ const ShortcutItem = fnObserver(({
         for (const registration of registrations) {
             if (registration.status !== WorkingSetStatus.REGISTERED
             && (registration.status !== WorkingSetStatus.MODIFIED || registration.changes.size > 0)) {
-                const gridEl = document.querySelector(`form[data-form-id] table[name="${registration.typeName}"]`);
+                const gridEl = document.querySelector(`form[data-domain-id="${registration.id}"] table[name="${registration.typeName}"]`);
                 if (isElementInSection(gridEl, reference)) {
                     count++;
                 } else {
                     for (const [name] of registration.changes) {
-                        const fieldEl = document.querySelector(`form[data-form-id] [name="${name}"]`);
+                        const fieldEl = document.querySelector(`form[data-domain-id="${registration.id}"] [name="${name}"]`);
                         if (isElementInSection(fieldEl, reference)) {
                             count++;
                         }


### PR DESCRIPTION
Use the newly introduced domain id in the dataset of forms to better identify field included in sections. This is needed because a field name can be used multiple times over many sections with different base domain objects.