### PR TITLE
Accept null value as tableConfig

### DIFF
--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -115,7 +115,7 @@ const DataGrid = fnObserver(props => {
         displayControlButtons,
         resetFilterButtonDisabled,
         customizeColumnsButtonDisabled,
-        tableConfig = {},
+        tableConfig,
         onTableConfigChange,
         moveRowColumn,
         moveRowHandler,
@@ -127,7 +127,7 @@ const DataGrid = fnObserver(props => {
         visibleColumns,
         paginationSize,
         sortColumn
-    } = tableConfig;
+    } = tableConfig ?? {};
 
     const visibleColumnsNotSet = !isArrayNotEmpty(visibleColumns) || visibleColumns.every((value) => !isStringNotEmpty(value));
 


### PR DESCRIPTION
Fix tableConfig in DataGrid to allow setting 'null' as value.