### PR TITLE
Integrate the context path into the history push

### DIFF
--- a/src/process/Process.js
+++ b/src/process/Process.js
@@ -1377,7 +1377,7 @@ function pushProcessState(replace = false)
 
     config.history[op](
         uri(
-            "/{appName}/{processName}/{stateName}/{info}",
+            `${config.contextPath}/{appName}/{processName}/{stateName}/{info}`,
             {
                 appName: config.appName,
                 processName: currentProcess.name,


### PR DESCRIPTION
History replace did remove the tomcat app path from the URI. Because of this, the applicaation could not be reloaded properly. This change ensures, that the application path is properly prepended to the newly generated URI.