### PR TITLE
Make placeholder for Date related fields optional

### DIFF
--- a/src/ui/CalendarField.js
+++ b/src/ui/CalendarField.js
@@ -74,11 +74,16 @@ const CalendarField = props => {
                     }
                     else
                     {
+                        const disablePlaceholder = mode === FieldMode.READ_ONLY || mode === FieldMode.DISABLED;
                         let placeholderAttribute;
-                        if (!(mode === FieldMode.READ_ONLY || mode === FieldMode.DISABLED)) {
-                            placeholderAttribute = placeholder || scalarType === "Date" ?
-                                i18n("Date Format {0}", dateFormat) :
-                                i18n("Timestamp Format {0}", timestampFormat);
+                        if (!disablePlaceholder) {
+                            if (placeholder === true) {
+                                placeholderAttribute = scalarType === "Date" ?
+                                    i18n("Date Format {0}", dateFormat) :
+                                    i18n("Timestamp Format {0}", timestampFormat);
+                            } else {
+                                placeholderAttribute = placeholder;
+                            }
                         }
 
                         fieldElement = Addon.renderWithAddons(
@@ -188,9 +193,10 @@ CalendarField.propTypes = {
     label: PropTypes.string,
 
     /**
-     * Placeholder text to render for text inputs.
+     * Placeholder text to render for text inputs or true for a default placeholder.
+     * By default no placeholder is rendered.
      */
-    placeholder: PropTypes.string,
+    placeholder: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
     /**
      * Additional HTML classes for the input element.

--- a/src/ui/form/date/DateRangeField.js
+++ b/src/ui/form/date/DateRangeField.js
@@ -82,9 +82,14 @@ const DateRangeField = props => {
                     }
                     else
                     {
+                        const disablePlaceholder = mode === FieldMode.READ_ONLY || mode === FieldMode.DISABLED;
                         let placeholderAttribute;
-                        if (!(mode === FieldMode.READ_ONLY || mode === FieldMode.DISABLED)) {
-                            placeholderAttribute = placeholder || i18n("Date Format {0}", dateFormat);
+                        if (!disablePlaceholder) {
+                            if (placeholder === true) {
+                                placeholderAttribute = i18n("Date Format {0}", dateFormat);
+                            } else {
+                                placeholderAttribute = placeholder;
+                            }
                         }
 
                         fieldElement = Addon.renderWithAddons(
@@ -194,9 +199,10 @@ DateRangeField.propTypes = {
     label: PropTypes.string,
 
     /**
-     * Placeholder text to render for text inputs.
+     * Placeholder text to render for text inputs or true for a default placeholder.
+     * By default no placeholder is rendered.
      */
-    placeholder: PropTypes.string,
+    placeholder: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
     /**
      * Additional HTML classes for the input element.


### PR DESCRIPTION
Setting placeholder to true will print the default placeholder, setting the attribute to a string will display the string instead. By default no placeholder is rendered.