### PR TITLE
A11y: Fix for MetaItem

### DIFF
--- a/src/ui/tree/MetaItem.js
+++ b/src/ui/tree/MetaItem.js
@@ -12,7 +12,7 @@ const MetaItem = ({ children }) => {
     const ctx = useContext( TreeContext );
 
     return (
-        <li className="meta-item">
+        <li className="meta-item" role="treeitem">
             <div className="wrapper">
                 <div className={ cx("header text-muted", ctx.options.small && "small")}>
                     {


### PR DESCRIPTION
Since it is inside a ul with the role 'group', the li needs the role 'treeitem' or it might not work well with screen readers.