### PR TITLE
Fix FKSelector and DateRange filter values

### DIFF
--- a/src/ui/datagrid/DataGrid.js
+++ b/src/ui/datagrid/DataGrid.js
@@ -17,7 +17,7 @@ import WorkingSet, { WorkingSetStatus } from "../../WorkingSet";
 import WorkingSetStatusComponent from "./WorkingSetStatus";
 import filterTransformer, { FieldResolver } from "../../util/filterTransformer";
 import config from "../../config"
-import { getCustomFilter, getCustomGetValue } from "../../util/filter/CustomFilter";
+import { getCustomFilter, getCustomGetValue, getCustomGetTemplate } from "../../util/filter/CustomFilter";
 import OfflineQuery from "../../model/OfflineQuery";
 import UserColumnConfigDialogModal from "./userconfig/UserColumnConfigDialogModal";
 import DataGridButtonToolbar from "./DataGridButtonToolbar";
@@ -219,6 +219,8 @@ const DataGrid = fnObserver(props => {
                 const {name, width, minWidth, filter, heading, suppressSort, sort, renderFilter, children : columnChildren } = columnElem.props;
                 const transformedFilter = getCustomFilter(filter) ?? filter;
                 const getValueFn = getCustomGetValue(filter);
+                const getTemplateFn = getCustomGetTemplate(filter);
+                
 
                 let typeRef = null, sortable = false, enabled = false;
                 if (name && typeof columnChildren !== "function")
@@ -271,6 +273,7 @@ const DataGrid = fnObserver(props => {
                     filter: transformedFilter,
                     filterIndex: null,
                     getValue: getValueFn,
+                    getTemplate: getTemplateFn,
                     enabled,
                     type: typeRef?.name,
                     heading: heading || name,

--- a/src/ui/datagrid/GridStateForm.js
+++ b/src/ui/datagrid/GridStateForm.js
@@ -277,12 +277,12 @@ function resolveFilters(columns, componentId, currentCondition)
     for (let i = 0; i < columns.length; i++)
     {
         const column = columns[i];
-        const { name, filter, filterIndex, getValue } = column;
+        const { name, filter, filterIndex, getValue, getTemplate } = column;
         if (filter)
         {
             if (typeof filter === "function")
             {
-                const template = invokeForTemplate(name, filter);
+                const template = typeof getTemplate === "function" ? getTemplate(name) : invokeForTemplate(name, filter);
 
                 const columnCondition = findConditionByTemplate(
                     componentId,

--- a/src/util/filter/CustomFilter.js
+++ b/src/util/filter/CustomFilter.js
@@ -1,5 +1,6 @@
 let filter = {};
 let getValue = {};
+let getTemplate = {};
 
 /**
  * Returns a stored filter function by alias
@@ -26,12 +27,25 @@ export function getCustomGetValue(name) {
 }
 
 /**
+ * Returns a stored template function by alias
+ *
+ * @param {String} name filter alias
+ */
+export function getCustomGetTemplate(name) {
+    if (name in getTemplate) {
+        return getTemplate[name];
+    }
+    return null;
+}
+
+/**
  * Remove all stored filters
  */
 export function removeAllCustomFilters()
 {
     filter = {};
     getValue = {};
+    getTemplate = {};
 }
 
 /**
@@ -43,21 +57,26 @@ export function removeCustomFilter(name)
 {
     filter[name] = null;
     getValue[name] = null;
+    getTemplate[name] = null;
 }
 
 /**
  * Register new filter alias
  *
  * @param {String} name filter alias
- * @param {function|String} filterFn function or name to be executed if filter is applied
+ * @param {function|String} [filterFn] function or name to be executed if filter is applied
  * @param {function} [getValueFn] function to extract filter value from condition object
+ * @param {function} [getTemplateFn] function to determine template value for condition extraction
  */
-export function registerCustomFilter(name, filterFn, getValueFn)
+export function registerCustomFilter(name, filterFn, getValueFn, getTemplateFn)
 {
     if (typeof filterFn === "function" || typeof filterFn === "string") {
         filter[name] = filterFn;
     }
     if (typeof getValueFn === "function") {
         getValue[name] = getValueFn;
+    }
+    if (typeof getTemplateFn === "function") {
+        getTemplate[name] = getTemplateFn;
     }
 }

--- a/src/util/filter/registerDateRangeFilter.js
+++ b/src/util/filter/registerDateRangeFilter.js
@@ -69,5 +69,5 @@ export function registerDateRangeFilter()
                 ]
             }
         ];
-    });
+    }, (fieldName) => field(fieldName).between(value(null, "Timestamp"), value(null, "Timestamp")));
 }

--- a/src/util/filter/registerFKSelectorFilter.js
+++ b/src/util/filter/registerFKSelectorFilter.js
@@ -34,7 +34,7 @@ export function registerFKSelectorFilterAndRenderer(name, query, rootType, sourc
             return field(fieldName).eq(value(fieldValue, "String"));
         }
         return null;
-    });
+    }, null, (fieldName) => field(fieldName).eq(value(null, "String")));
 
     registerCustomFilterRenderer(name, (fieldName, fieldType, label) => {
         const formConfig = useFormConfig();


### PR DESCRIPTION
The filter values would reset themselfes after the query returned from the server. This was due to the returning values not being interpreted correctly.
Add a new (optional) custom template function register to registerCustomFilter, where a template for resolving filter values can be dafined without setting errornous values for the request query.