### PR TITLE
Add likePattern filter

### DIFF
--- a/src/startup.js
+++ b/src/startup.js
@@ -32,6 +32,7 @@ import {registerDateRangeFilter} from "./util/filter/registerDateRangeFilter";
 import {registerNumberFilter} from "./util/filter/registerNumberFilter";
 import registerStringSetConverter from "./util/converter/registerStringSetConverter";
 import { registerRequestForSession } from "./util/latestRequestInSession"
+import { registerLikePatternFilter } from "./util/filter/registerLikePatternFilter"
 
 
 const SCOPES_MODULE_NAME = "./scopes.js";
@@ -189,6 +190,7 @@ function defaultInit(ctx, initial)
 
     registerDateRangeFilter();
     registerNumberFilter();
+    registerLikePatternFilter();
 
     registerStringSetConverter();
 

--- a/src/util/converter/SearchStringConverter.js
+++ b/src/util/converter/SearchStringConverter.js
@@ -1,0 +1,106 @@
+function parseWildcard(searchString) {
+    if (!searchString.includes("*")) {
+        return `^.*${searchString}.*$`;
+    }
+    return `^${searchString.replace(/\*+/g, ".*")}$`;
+}
+
+function parseNot(searchString) {
+    searchString = searchString.trim();
+    if (searchString.startsWith("!")) {
+        return `(?:(?!${parseWildcard(searchString.slice(1))})^.*$)`;
+    }
+    return parseWildcard(searchString);
+}
+
+function parseAnd(searchString) {
+    const result = searchString.split("&").map(parseNot);
+    if (result.length > 1) {
+        return `(?=${result.join(")(?=")}).*`;
+    }
+    return result[0];
+}
+
+function parseOr(searchString) {
+    return searchString.split("/").map(parseAnd).join("|");
+}
+
+/**
+ * Turns a search string into a RegExp string with the following rules:
+ * - a wilcard is written as "*"
+ * - "and" is written as "&"
+ * - "or" is written as "/"
+ * - "not" is written as "!"
+ * - no brackets
+ * - "and" binds stronger than "or"
+ * - if there is no expression, just match as contains
+ * 
+ * @param searchString {string} the search string to be parsed
+ * @returns {string} the resulting RegExp string
+ */
+export function parseSearch(searchString) {
+    if (searchString == null || searchString === "" || (!searchString.includes("&") && !searchString.includes("/") && !searchString.includes("*") && !searchString.includes("!"))) {
+        return searchString;
+    }
+    console.group("parseSearch")
+    console.log("String to parse:", searchString);
+    const resultRegExp = parseOr(searchString);
+    console.log("resulting RegExp:", resultRegExp);
+    console.groupEnd("parseSearch")
+    return resultRegExp;
+}
+
+
+function stringifyWildcard(regExpString) {
+    regExpString = regExpString.replace(/^\^|\$$/g, "");
+    if (regExpString.startsWith(".*") && regExpString.endsWith(".*")) {
+        const sliced = regExpString.slice(2, -2);
+        if (!sliced.includes(".*")) {
+            return sliced;
+        }
+    }
+    return regExpString.replace(/\.\*/g, "*");
+}
+
+function stringifyNot(regExpString) {
+    if (regExpString.startsWith("(?:(?!") && regExpString.endsWith(")^.*$)")) {
+        return `!${stringifyWildcard(regExpString.slice(6, -6))}`;
+    }
+    return stringifyWildcard(regExpString);
+}
+
+function stringifyAnd(regExpString) {
+    if (regExpString.startsWith("(?=") && regExpString.endsWith(").*")) {
+        return regExpString.slice(3, -3).split(")(?=").map(stringifyNot).join(" & ");
+    }
+    return stringifyNot(regExpString);
+}
+
+function stringifyOr(regExpString) {
+    return regExpString.split("|").map(stringifyAnd).join(" / ");
+}
+
+/**
+ * Turns a RegExp string into a search string with the following rules:
+ * - a wilcard is written as "*"
+ * - "and" is written as "&"
+ * - "or" is written as "/"
+ * - "not" is written as "!"
+ * - no brackets
+ * - "and" binds stronger than "or"
+ * - if there is no expression, just match as contains
+ * 
+ * @param regExpString {string} the RegExp string to be parsed
+ * @returns {string} the resulting search string
+ */
+export function stringifySearch(regExpString) {
+    if (regExpString == null || regExpString === "") {
+        return regExpString;
+    }
+    console.group("stringifySearch");
+    console.log("RegExp to stringify:", regExpString);
+    const resultString = stringifyOr(regExpString);
+    console.log("resulting String:", resultString);
+    console.groupEnd("stringifySearch");
+    return resultString;
+}

--- a/src/util/converter/SearchStringConverter.js
+++ b/src/util/converter/SearchStringConverter.js
@@ -42,11 +42,7 @@ export function parseSearch(searchString) {
     if (searchString == null || searchString === "" || (!searchString.includes("&") && !searchString.includes("/") && !searchString.includes("*") && !searchString.includes("!"))) {
         return searchString;
     }
-    console.group("parseSearch")
-    console.log("String to parse:", searchString);
     const resultRegExp = parseOr(searchString);
-    console.log("resulting RegExp:", resultRegExp);
-    console.groupEnd("parseSearch")
     return resultRegExp;
 }
 
@@ -97,10 +93,6 @@ export function stringifySearch(regExpString) {
     if (regExpString == null || regExpString === "") {
         return regExpString;
     }
-    console.group("stringifySearch");
-    console.log("RegExp to stringify:", regExpString);
     const resultString = stringifyOr(regExpString);
-    console.log("resulting String:", resultString);
-    console.groupEnd("stringifySearch");
     return resultString;
 }

--- a/src/util/filter/registerLikePatternFilter.js
+++ b/src/util/filter/registerLikePatternFilter.js
@@ -1,0 +1,39 @@
+import {registerCustomFilter} from "./CustomFilter";
+import {field, value} from "../../../filter";
+import { parseSearch, stringifySearch } from "../converter/SearchStringConverter";
+import { extractValueNodes } from "../../ui/datagrid/GridStateForm";
+import i18n from "../../i18n";
+
+/**
+ * Creates and registers the filter for pattern input.
+ * 
+ * Filter rules are as follows:
+ * - a wilcard is written as "*"
+ * - "and" is written as "&"
+ * - "or" is written as "/"
+ * - "not" is written as "!"
+ * - no brackets
+ * - "and" binds stronger than "or"
+ * - if there is no expression, just match as contains
+ */
+export function registerLikePatternFilter()
+{
+    registerCustomFilter("likePattern", (fieldName, val) => {
+        if (val == null) {
+            val = ""
+        }
+        const stringValue = val.toString();
+        const regExpString = parseSearch(stringValue);
+        return field(fieldName).toString().likeRegex(value(regExpString, "String"));
+    }, (column, columnCondition) => {
+        const valueNodes = extractValueNodes(columnCondition);
+        const regExpString = valueNodes?.[0]?.value;
+        return [
+            {
+                type: "String",
+                label: i18n("Filter:" + column.name),
+                value: stringifySearch(regExpString)
+            }
+        ];
+    });
+}


### PR DESCRIPTION
Add a filter that allows user input with minimal logic for more refined filtering.
That includes operators "and", "or" and "not" as well as wildcards.

Usage:
Set the "likePattern" filter to the filter attribute of the column where this filter is needed.

Input conversion:
 a wilcard is written as "*"
 "and" is written as "&"
 "or" is written as "/"
 "not" is written as "!"
 "and" binds stronger than "or"
 if there is no expression, it just matches as contains