### PR TITLE
Fix onChange in QueryEditor

### DIFF
--- a/src/ui/queryeditor/QueryEditor.js
+++ b/src/ui/queryeditor/QueryEditor.js
@@ -78,15 +78,14 @@ const QueryEditor = (props) => {
                 formContext.revalidate();
         
                 const queryColumns = get(container, selectedColumnsPath);
-                if (formContext.getErrors().length <= 0) {
-                    const queryCondition = get(container, queryConditionPath);
-                    const querySort = get(container, sortColumnsPath);
-                    onChange({
-                        select: queryColumns ?? [],
-                        where: queryCondition,
-                        sort: querySort ?? []
-                    });
-                }
+                const queryCondition = get(container, queryConditionPath);
+                const querySort = get(container, sortColumnsPath);
+                onChange({
+                    select: queryColumns ?? [],
+                    where: queryCondition,
+                    sort: querySort ?? [],
+                    hasFormContextErrors: formContext.getErrors().length <= 0
+                });
             };
         }
         return () => {}


### PR DESCRIPTION
Fix it so the onChange callback is called even with errors in the FormContext. add hasFormContextErrors to the callback parameter object instead.