### PR TITLE
Fix likePattern filter to only be applied if set

### DIFF
--- a/src/util/filter/registerLikePatternFilter.js
+++ b/src/util/filter/registerLikePatternFilter.js
@@ -19,8 +19,8 @@ import i18n from "../../i18n";
 export function registerLikePatternFilter()
 {
     registerCustomFilter("likePattern", (fieldName, val) => {
-        if (val == null) {
-            val = ""
+        if (val == null || val === "") {
+            return null
         }
         const stringValue = val.toString();
         const regExpString = parseSearch(stringValue);
@@ -35,5 +35,5 @@ export function registerLikePatternFilter()
                 value: stringifySearch(regExpString)
             }
         ];
-    });
+    }, (fieldName) => field(fieldName).toString().likeRegex(value(null, "String")));
 }


### PR DESCRIPTION
The filter value for the likePattern filter was generated even if its field was empty. This is now fixed by returning a null value if the filter is not set or empty. For the filter decompiler a filter value template getter is added.