### PR TITLE
Add filter renderer for likePattern

### DIFF
--- a/src/util/converter/SearchStringConverter.js
+++ b/src/util/converter/SearchStringConverter.js
@@ -1,5 +1,25 @@
 import config from "../../config";
 
+/**
+ * word  = (?:\!?(?:\*\s*)?[^*!&\/\s]+(?:\s*\*?\s*[^*!&\/\s]+)*(?:\s*\*)?)
+ * extra = (?:\s*[&\/]\s*${word})*
+ * regex = ^(?:${word}${extra})?$
+ */
+const VALID_FILTER_PATTERN = /^(?:(?:\!?(?:\*\s*)?[^*!&\/\s]+(?:\s*\*?\s*[^*!&\/\s]+)*(?:\s*\*)?)(?:\s*[&\/]\s*(?:\!?(?:\*\s*)?[^*!&\/\s]+(?:\s*\*?\s*[^*!&\/\s]+)*(?:\s*\*)?))*)?$/;
+
+/**
+ * Checks whether the entered String is a valid pattern
+ * 
+ * @param searchString {string} the search string to be validated
+ * @returns {null|string} null if is valid, "Not a valid pattern" otherwise
+ */
+export function validateSearch(searchString) {
+    if (!VALID_FILTER_PATTERN.test(searchString)) {
+        return "Not a valid pattern";
+    }
+    return null;
+}
+
 const REGEXP_ESCAPE = /[.+?^${}()|[\]\\]/g;
 const SUBSTI_ESCAPE = "\\$&";
 const REGEXP_UNESCAPE = /\\([.+?^${}()|[\]\\])/g;

--- a/src/util/filter/registerLikePatternFilter.js
+++ b/src/util/filter/registerLikePatternFilter.js
@@ -1,8 +1,11 @@
+import React from "react";
 import {registerCustomFilter} from "./CustomFilter";
+import { registerCustomFilterRenderer } from "./CustomFilterRenderer";
 import {field, value} from "../../../filter";
-import { parseSearch, stringifySearch } from "../converter/SearchStringConverter";
+import { parseSearch, stringifySearch, validateSearch } from "../converter/SearchStringConverter";
 import { extractValueNodes } from "../../ui/datagrid/GridStateForm";
 import i18n from "../../i18n";
+import { Field } from "domainql-form";
 
 /**
  * Creates and registers the filter for pattern input.
@@ -18,7 +21,9 @@ import i18n from "../../i18n";
  */
 export function registerLikePatternFilter()
 {
-    registerCustomFilter("likePattern", (fieldName, val) => {
+    const NAME = "likePattern";
+
+    registerCustomFilter(NAME, (fieldName, val) => {
         if (val == null || val === "") {
             return null
         }
@@ -36,4 +41,20 @@ export function registerLikePatternFilter()
             }
         ];
     }, (fieldName) => field(fieldName).toString().likeRegex(value(null, "String")));
+
+    registerCustomFilterRenderer(NAME, (fieldName, fieldType, label) => {
+        if (!fieldType) {
+            const fieldSchemaType = config.inputSchema.resolveType(rootType, sourceName);
+            fieldType = getScalarType(fieldSchemaType);
+        }
+        return(
+            <Field
+                labelClass="sr-only"
+                label={ label }
+                name={fieldName}
+                type={ fieldType }
+                validate={ (ctx, value) => validateSearch(value) }
+            />
+        );
+    });
 }


### PR DESCRIPTION
The renderer creates an input with validation to ensure only valid pattern are send to the server.
The validation method has been added to SearchStringConverter.

To call the renderer, set the renderFilter property of the DataGrid column to "likePattern".