### PR TITLE
fix BigDecimal validation function to include all used decimal places

### DIFF
--- a/src/registerBigDecimalConverter.js
+++ b/src/registerBigDecimalConverter.js
@@ -168,7 +168,12 @@ export default function registerBigDecimalConverter(opts) {
                 return i18n("Invalid Big Decimal");
             }
 
-            if (!num.isFinite() || num.precision() > p.precision)
+            let ommittedDecimalPlaces = 0;
+            if (ctx.padToScale && p.scale != null) {
+                ommittedDecimalPlaces = p.scale - num.decimalPlaces();
+            }
+
+            if (!num.isFinite() || num.precision(true) + ommittedDecimalPlaces > p.precision)
             {
                 return i18n("Out of range");
             }


### PR DESCRIPTION
default behaviour of precision getter in bignumber, if no precision was defined, is to count the places, that come before the last 0 sequence. so 2000.00 would return a precision of 1 while 20.01 has a precision of 4

LISAWEB-2660